### PR TITLE
Step 4: JWT認証実装

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,10 +7,8 @@ SUPABASE_URL=https://your-project-id.supabase.co
 # ⚠️ Secret Key - Keep this secret! Never commit to Git!
 SUPABASE_KEY=sb_secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# JWT Secret for token verification (legacy HS256)
-# New projects may use JWT Signing Keys instead (asymmetric)
-# Get this from: Project Settings > API > JWT Settings
-SUPABASE_JWT_SECRET=your-super-secret-jwt-secret-with-at-least-256-bits
+# JWT: RS256（JWT Signing Keys）を使用しているため SUPABASE_JWT_SECRET は不要
+# 公開鍵は起動時に自動取得: {SUPABASE_URL}/auth/v1/.well-known/jwks.json
 
 # AWS S3 Configuration
 S3_BUCKET_NAME=scrappa-images

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -1,0 +1,44 @@
+import os
+import httpx
+from fastapi import Header, HTTPException
+from jose import jwt, JWTError
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+
+# 公開鍵キャッシュ（起動後初回リクエスト時に取得）
+_jwks_cache = None
+
+
+def _fetch_jwks() -> dict:
+    global _jwks_cache
+    if _jwks_cache is None:
+        response = httpx.get(f"{SUPABASE_URL}/auth/v1/.well-known/jwks.json")
+        response.raise_for_status()
+        _jwks_cache = response.json()
+    return _jwks_cache
+
+
+async def get_current_user(authorization: str = Header(None)) -> str:
+    """
+    AuthorizationヘッダーのBearerトークン（Supabase JWT）を検証してuser_idを返す。
+    RS256（非対称暗号）でSupabaseのJWKSエンドポイントから取得した公開鍵で検証。
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    token = authorization.split(" ", 1)[1]
+
+    try:
+        jwks = _fetch_jwks()
+        payload = jwt.decode(
+            token,
+            jwks,
+            algorithms=["RS256"],
+            audience="authenticated",
+        )
+        user_id: str = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user_id
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")

--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from typing import Optional
 import uuid
 import json
@@ -7,6 +7,7 @@ from app.models.clip import ClipResponse
 from app.services.image import process_image
 from app.services.storage import upload_to_s3
 from app.db.supabase import supabase
+from app.middleware.auth import get_current_user
 
 router = APIRouter()
 
@@ -14,7 +15,8 @@ router = APIRouter()
 async def create_clip(
     file: UploadFile = File(..., description="画像ファイル（JPEG/PNG/WebP、10MB以下）"),
     tags: Optional[str] = Form(default="[]", description="タグ名のリスト（JSON配列文字列: '[\"ロゴ\", \"モノクロ\"]'）"),
-    page: Optional[int] = Form(default=None, description="配置ページ番号")
+    page: Optional[int] = Form(default=None, description="配置ページ番号"),
+    user_id: str = Depends(get_current_user),
 ):
     """
     画像をアップロードしてクリップを作成
@@ -40,9 +42,6 @@ async def create_clip(
     clip_id = str(uuid.uuid4())
     filename = f"clips/{clip_id}.jpg"
     image_url = upload_to_s3(processed_image, filename)
-    
-    # 4. Supabaseに保存（認証なし版：固定user_id）
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
     
     # ページ番号決定（省略時は最終ページ）
     if page is None:
@@ -122,16 +121,16 @@ async def create_clip(
 async def get_clips(
     tag: Optional[str] = None,
     page: int = 1,
-    limit: int = 24
+    limit: int = 24,
+    user_id: str = Depends(get_current_user),
 ):
     """
     クリップ一覧を取得
-    
+
     - **tag**: タグ名でフィルタ（省略可）
     - **page**: ページ番号（デフォルト: 1）
     - **limit**: 取得件数（デフォルト: 24）
     """
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
     
     # オフセット計算
     offset = (page - 1) * limit

--- a/backend/app/routers/tags.py
+++ b/backend/app/routers/tags.py
@@ -1,56 +1,49 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from app.models.tag import TagCreate, TagResponse, TagUpdate
 from app.db.supabase import supabase
+from app.middleware.auth import get_current_user
 
 router = APIRouter()
 
 @router.get("/", response_model=dict)
-async def get_tags():
+async def get_tags(user_id: str = Depends(get_current_user)):
     """タグ一覧を取得（clip_count付き）"""
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
-    
-    # タグ一覧取得
     response = supabase.table("tags")\
         .select("*")\
         .eq("user_id", user_id)\
         .execute()
-    
+
     tags_with_count = []
     for tag in response.data:
-        # このタグが付いたクリップ数を取得
         count_response = supabase.table("clip_tags")\
             .select("clip_id", count="exact")\
             .eq("tag_id", tag["id"])\
             .execute()
-        
+
         tags_with_count.append({
             "id": tag["id"],
             "name": tag["name"],
             "clip_count": count_response.count
         })
-    
+
     return {"tags": tags_with_count}
 
 @router.post("/", response_model=TagResponse, status_code=201)
-async def create_tag(tag: TagCreate):
+async def create_tag(tag: TagCreate, user_id: str = Depends(get_current_user)):
     """タグを作成"""
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
-    
-    # 同名タグが存在するか確認
     response = supabase.table("tags")\
         .select("*")\
         .eq("user_id", user_id)\
         .eq("name", tag.name)\
         .execute()
-    
+
     if response.data:
         raise HTTPException(status_code=400, detail="同名のタグが既に存在します")
-    
-    # タグ作成
+
     tag_data = {"user_id": user_id, "name": tag.name}
     response = supabase.table("tags").insert(tag_data).execute()
     created_tag = response.data[0]
-    
+
     return TagResponse(
         id=created_tag["id"],
         name=created_tag["name"],
@@ -58,34 +51,29 @@ async def create_tag(tag: TagCreate):
     )
 
 @router.patch("/{tag_id}", response_model=TagResponse)
-async def update_tag(tag_id: str, tag: TagUpdate):
+async def update_tag(tag_id: str, tag: TagUpdate, user_id: str = Depends(get_current_user)):
     """タグ名を変更"""
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
-    
-    # タグ存在確認
     response = supabase.table("tags")\
         .select("*")\
         .eq("id", tag_id)\
         .eq("user_id", user_id)\
         .execute()
-    
+
     if not response.data:
         raise HTTPException(status_code=404, detail="タグが見つかりません")
-    
-    # タグ名更新
+
     response = supabase.table("tags")\
         .update({"name": tag.name})\
         .eq("id", tag_id)\
         .execute()
-    
+
     updated_tag = response.data[0]
-    
-    # clip_count取得
+
     count_response = supabase.table("clip_tags")\
         .select("clip_id", count="exact")\
         .eq("tag_id", tag_id)\
         .execute()
-    
+
     return TagResponse(
         id=updated_tag["id"],
         name=updated_tag["name"],
@@ -93,21 +81,17 @@ async def update_tag(tag_id: str, tag: TagUpdate):
     )
 
 @router.delete("/{tag_id}", status_code=204)
-async def delete_tag(tag_id: str):
+async def delete_tag(tag_id: str, user_id: str = Depends(get_current_user)):
     """タグを削除"""
-    user_id = "00000000-0000-0000-0000-000000000001"  # Step 4で実際の認証に置き換え
-    
-    # タグ存在確認
     response = supabase.table("tags")\
         .select("*")\
         .eq("id", tag_id)\
         .eq("user_id", user_id)\
         .execute()
-    
+
     if not response.data:
         raise HTTPException(status_code=404, detail="タグが見つかりません")
-    
-    # タグ削除（clip_tagsはCASCADEで自動削除）
+
     supabase.table("tags").delete().eq("id", tag_id).execute()
-    
+
     return None  # 204 No Content

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ python-jose[cryptography]>=3.3.0,<4.0.0
 # Validation & Utils
 python-multipart>=0.0.9,<1.0.0
 pydantic>=2.5.0,<3.0.0
+httpx>=0.27.0,<1.0.0


### PR DESCRIPTION
## Summary
- Supabase JWT（RS256）を検証する `get_current_user` ミドルウェアを実装
- JWKS エンドポイントから公開鍵を自動取得・キャッシュする方式を採用（`SUPABASE_JWT_SECRET` 不要）
- `POST /clips`・`GET /clips`・全タグ API に認証を適用
- `httpx` を依存関係に追加
- `.env.example` を RS256 方式の説明に更新

## Test plan
- [ ] Swagger UI の Authorize に Bearer トークンを設定し `POST /clips` が 201 を返すことを確認
- [ ] トークンなしで `POST /clips` にアクセスし 401 が返ることを確認
- [ ] 無効なトークンで 401 が返ることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)