### PR TITLE
feat: クロップUIにズーム拡大・回転スライダーを追加

### DIFF
--- a/frontend/src/components/upload/UploadModal.css
+++ b/frontend/src/components/upload/UploadModal.css
@@ -227,6 +227,27 @@
   padding-top: 12px;
 }
 
+.crop-control-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.crop-control-label {
+  font-size: 0.75rem;
+  color: #888;
+  white-space: nowrap;
+  min-width: 28px;
+}
+
+.crop-control-value {
+  font-size: 0.75rem;
+  color: #888;
+  min-width: 32px;
+  text-align: right;
+}
+
 .zoom-slider {
   width: 100%;
   accent-color: #2c5f2e;

--- a/frontend/src/components/upload/UploadModal.jsx
+++ b/frontend/src/components/upload/UploadModal.jsx
@@ -17,6 +17,7 @@ export default function UploadModal({ onClose, onUploaded }) {
   // react-easy-crop の状態
   const [crop, setCrop] = useState({ x: 0, y: 0 })
   const [zoom, setZoom] = useState(1)
+  const [rotation, setRotation] = useState(0)
   const [croppedAreaPixels, setCroppedAreaPixels] = useState(null)
 
   const [selectedTags, setSelectedTags] = useState([])
@@ -42,6 +43,7 @@ export default function UploadModal({ onClose, onUploaded }) {
     setPhase('crop')
     setCrop({ x: 0, y: 0 })
     setZoom(1)
+    setRotation(0)
   }
 
   const handleFileSelect = (e) => {
@@ -74,7 +76,7 @@ export default function UploadModal({ onClose, onUploaded }) {
 
   // 「確定」ボタン → Canvas APIでクロップ済みblobを生成してプレビューへ
   const handleCropConfirm = async () => {
-    const blob = await getCroppedBlob(imageSrc, croppedAreaPixels)
+    const blob = await getCroppedBlob(imageSrc, croppedAreaPixels, rotation)
     const croppedFile = new File([blob], 'cropped.jpg', { type: 'image/jpeg' })
     setFile(croppedFile)
     setPreview(URL.createObjectURL(blob))
@@ -158,22 +160,40 @@ export default function UploadModal({ onClose, onUploaded }) {
                   image={imageSrc}
                   crop={crop}
                   zoom={zoom}
+                  rotation={rotation}
                   aspect={1}
                   onCropChange={setCrop}
                   onZoomChange={setZoom}
+                  onRotationChange={setRotation}
                   onCropComplete={onCropComplete}
                 />
               </div>
               <div className="crop-controls">
-                <input
-                  className="zoom-slider"
-                  type="range"
-                  min={1}
-                  max={3}
-                  step={0.1}
-                  value={zoom}
-                  onChange={(e) => setZoom(Number(e.target.value))}
-                />
+                <div className="crop-control-row">
+                  <span className="crop-control-label">拡大</span>
+                  <input
+                    className="zoom-slider"
+                    type="range"
+                    min={1}
+                    max={10}
+                    step={0.1}
+                    value={zoom}
+                    onChange={(e) => setZoom(Number(e.target.value))}
+                  />
+                </div>
+                <div className="crop-control-row">
+                  <span className="crop-control-label">傾き</span>
+                  <input
+                    className="zoom-slider"
+                    type="range"
+                    min={-45}
+                    max={45}
+                    step={1}
+                    value={rotation}
+                    onChange={(e) => setRotation(Number(e.target.value))}
+                  />
+                  <span className="crop-control-value">{rotation}°</span>
+                </div>
                 <button className="crop-confirm-btn" onClick={handleCropConfirm}>
                   確定
                 </button>

--- a/frontend/src/lib/cropImage.js
+++ b/frontend/src/lib/cropImage.js
@@ -11,26 +11,47 @@ function createImage(url) {
 }
 
 /**
- * react-easy-cropが返すcroppedAreaPixels座標を使って
+ * react-easy-cropが返すcroppedAreaPixels座標と回転角度を使って
  * Canvas APIでクロップ済みのJPEG Blobを生成する
  *
  * @param {string} imageSrc - 元画像のblob URL
  * @param {{ x: number, y: number, width: number, height: number }} pixelCrop - クロップ範囲（ピクセル）
+ * @param {number} rotation - 回転角度（度数法、デフォルト0）
  * @returns {Promise<Blob>} クロップ済みのJPEG Blob
  */
-export async function getCroppedBlob(imageSrc, pixelCrop) {
+export async function getCroppedBlob(imageSrc, pixelCrop, rotation = 0) {
   const image = await createImage(imageSrc)
   const canvas = document.createElement('canvas')
-  canvas.width = pixelCrop.width
-  canvas.height = pixelCrop.height
   const ctx = canvas.getContext('2d')
 
-  // 元画像の指定範囲だけをcanvasに描画（= トリミング）
-  // drawImage 9引数: (image, sx, sy, sw, sh, dx, dy, dw, dh)
+  // 回転後に画像がはみ出さないよう、対角線長のsafeAreaを確保
+  const maxSize = Math.max(image.width, image.height)
+  const safeArea = 2 * ((maxSize / 2) * Math.sqrt(2))
+
+  canvas.width = safeArea
+  canvas.height = safeArea
+
+  // キャンバス中心を基準に回転
+  ctx.translate(safeArea / 2, safeArea / 2)
+  ctx.rotate((rotation * Math.PI) / 180)
+  ctx.translate(-safeArea / 2, -safeArea / 2)
+
+  // 回転した状態で画像を中央に描画
   ctx.drawImage(
     image,
-    pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height,
-    0, 0, pixelCrop.width, pixelCrop.height
+    safeArea / 2 - image.width / 2,
+    safeArea / 2 - image.height / 2
+  )
+
+  // 回転済みのピクセルデータを取得し、クロップ範囲だけ切り出す
+  const data = ctx.getImageData(0, 0, safeArea, safeArea)
+  canvas.width = pixelCrop.width
+  canvas.height = pixelCrop.height
+
+  ctx.putImageData(
+    data,
+    Math.round(0 - safeArea / 2 + image.width / 2 - pixelCrop.x),
+    Math.round(0 - safeArea / 2 + image.height / 2 - pixelCrop.y)
   )
 
   return new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.95))


### PR DESCRIPTION
## Summary

- ズーム上限を3倍 → **10倍**に拡大
- **傾きスライダー**（-45°〜+45°、1°刻み）を追加し左右の傾き補正に対応
- Canvas描画ロジック（getCroppedBlob）を回転対応に書き換え（safeArea方式）
- 画像選び直し時に回転を0°にリセット

## Test plan

- [ ] ズームスライダーを最大にすると10倍まで拡大できる
- [ ] 傾きスライダーを動かすと画像が回転し、角度（°）が表示される
- [ ] 「確定」後のプレビューに回転が正しく反映されている
- [ ] 回転0°のときは従来と同じクロップ結果になる
- [ ] 別の画像を選び直すと回転が0°にリセットされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)