### PR TITLE
fix: タグ取得をFKジョインから明示的クエリに変更しタグ編集が反映されない不具合を修正

### DIFF
--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -176,22 +176,40 @@ async def get_clips(
             .execute()
     
     clips_data = response.data
-    
-    # 各クリップのタグを取得
+
+    # タグを一括取得（N+1を避けるため3クエリで処理）
     clips_with_tags = []
-    for clip in clips_data:
-        # タグ取得（JOIN: clip_tags + tags）
-        tags_response = supabase.table("clip_tags")\
-            .select("tag_id, tags(name)")\
-            .eq("clip_id", clip["id"])\
+    if clips_data:
+        clip_ids = [clip["id"] for clip in clips_data]
+
+        # clip_tags を一括取得
+        ct_response = supabase.table("clip_tags")\
+            .select("clip_id, tag_id")\
+            .in_("clip_id", clip_ids)\
             .execute()
-        
-        tag_names = [item["tags"]["name"] for item in tags_response.data]
-        
-        clips_with_tags.append({
-            **clip,
-            "tags": tag_names
-        })
+
+        # tag_id → tag_name のマップを作成
+        tag_ids = list({row["tag_id"] for row in ct_response.data})
+        tag_id_to_name = {}
+        if tag_ids:
+            tags_response = supabase.table("tags")\
+                .select("id, name")\
+                .in_("id", tag_ids)\
+                .execute()
+            tag_id_to_name = {row["id"]: row["name"] for row in tags_response.data}
+
+        # clip_id → [tag_name] のマップを作成
+        clip_tags_map: dict = {}
+        for row in ct_response.data:
+            name = tag_id_to_name.get(row["tag_id"])
+            if name:
+                clip_tags_map.setdefault(row["clip_id"], []).append(name)
+
+        for clip in clips_data:
+            clips_with_tags.append({
+                **clip,
+                "tags": clip_tags_map.get(clip["id"], [])
+            })
     
     # 総件数取得
     count_response = supabase.table("clips")\


### PR DESCRIPTION
## 問題

クリップ編集画面でタグを追加・保存しても反映されない不具合。

## 原因

`GET /clips/` でタグを取得する際に Supabase の FK ジョイン構文 `.select("tag_id, tags(name)")` を使用していたが、`clip_tags` に行が存在するときに `item["tags"]` が `None` となるケースがあり、タグ保存後の `refetch()` が 500 エラーで失敗していた。

```
1. PATCH /clips/{id}/  → タグ保存: 成功
2. refetch() → GET /clips/ → 500 エラー（FK ジョイン失敗）
3. clips が更新されず → UI に反映されない
```

## 修正

FK ジョインを使わず `clip_tags` → `tags` を個別クエリで取得する方式に変更。
あわせてN+1クエリも解消し、全クリップで合計3クエリに最適化。

```python
# Before（FK ジョイン・N+1）
for clip in clips_data:
    tags_response = supabase.table("clip_tags")
        .select("tag_id, tags(name)")  # FK ジョイン
        .eq("clip_id", clip["id"])
        .execute()
    tag_names = [item["tags"]["name"] for item in tags_response.data]

# After（明示的クエリ・3クエリで完結）
ct_response  = supabase.table("clip_tags").select("clip_id, tag_id").in_("clip_id", clip_ids)
tags_response = supabase.table("tags").select("id, name").in_("id", tag_ids)
# clip_id → [tag_name] にマッピング
```

## Test plan

- [ ] タグを追加して「保存」後、クリップを再度開くと追加したタグが表示される
- [ ] タグを削除して「保存」後、クリップを再度開くとタグが消えている
- [ ] タグなしのクリップが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)