### PR TITLE
feat: ヘッダーにユーザーメニューを追加（プロフィール編集・ログアウト）

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import clips, tags
+from app.routers import clips, tags, users
 
 app = FastAPI(
     title="Scrappa API",
@@ -23,6 +23,7 @@ app.add_middleware(
 # ルーター登録
 app.include_router(clips.router, prefix="/clips", tags=["clips"])
 app.include_router(tags.router, prefix="/tags", tags=["tags"])
+app.include_router(users.router, prefix="/users", tags=["users"])
 
 @app.get("/")
 def root():

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+
+from app.services.image import process_avatar_image
+from app.services.storage import upload_to_s3
+from app.middleware.auth import get_current_user
+
+router = APIRouter()
+
+
+@router.post("/me/avatar", response_model=dict)
+async def upload_avatar(
+    file: UploadFile = File(...),
+    user_id: str = Depends(get_current_user),
+):
+    """
+    アバター画像をアップロードして S3 URL を返す
+    """
+    if file.content_type not in ["image/jpeg", "image/png", "image/webp"]:
+        raise HTTPException(status_code=400, detail="JPEG/PNG/WebPのみ対応")
+
+    file_bytes = await file.read()
+    if len(file_bytes) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=400, detail="ファイルサイズは5MB以下")
+
+    processed = process_avatar_image(file_bytes)
+    url = upload_to_s3(processed, f"avatars/{user_id}.jpg")
+
+    return {"avatar_url": url}

--- a/backend/app/services/image.py
+++ b/backend/app/services/image.py
@@ -57,6 +57,14 @@ def resize_and_compress(image_bytes: bytes, size: int = 300) -> bytes:
     img_resized.save(output, format='JPEG', quality=75, optimize=True)
     return output.getvalue()
 
+def process_avatar_image(image_bytes: bytes) -> bytes:
+    """
+    アバター画像処理（センタークロップ → 200×200px）
+    """
+    cropped = center_crop_to_square(image_bytes)
+    processed = resize_and_compress(cropped, size=200)
+    return processed
+
 def process_image(image_bytes: bytes) -> bytes:
     """
     画像処理の完全なパイプライン

--- a/frontend/src/components/user/UserMenu.css
+++ b/frontend/src/components/user/UserMenu.css
@@ -1,0 +1,105 @@
+.user-menu {
+  position: relative;
+}
+
+.user-avatar-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s;
+}
+
+.user-avatar-btn:hover {
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.user-avatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.user-avatar-initials {
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+/* オーバーレイ（外側クリックで閉じる） */
+.user-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+}
+
+/* ドロップダウン本体 */
+.user-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 200px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 11;
+  overflow: hidden;
+}
+
+.user-menu-info {
+  padding: 12px 16px;
+}
+
+.user-menu-name {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #222;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu-email {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu-divider {
+  margin: 0;
+  border: none;
+  border-top: 1px solid #eee;
+}
+
+.user-menu-item {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  text-align: left;
+  background: none;
+  border: none;
+  font-size: 0.88rem;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.user-menu-item:hover {
+  background-color: #f5f0e8;
+}
+
+.user-menu-item--logout {
+  color: #c0392b;
+}

--- a/frontend/src/components/user/UserMenu.jsx
+++ b/frontend/src/components/user/UserMenu.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import UserProfileModal from './UserProfileModal'
+import './UserMenu.css'
+
+export default function UserMenu({ user, onLogout, onUserUpdated }) {
+  const [open, setOpen] = useState(false)
+  const [showProfile, setShowProfile] = useState(false)
+
+  const displayName = user.user_metadata?.display_name
+    || user.user_metadata?.full_name
+    || user.email
+  const avatarUrl = user.user_metadata?.avatar_url
+
+  return (
+    <div className="user-menu">
+      <button className="user-avatar-btn" onClick={() => setOpen(!open)}>
+        {avatarUrl
+          ? <img src={avatarUrl} alt="avatar" className="user-avatar" />
+          : <span className="user-avatar-initials">{displayName?.[0]?.toUpperCase()}</span>
+        }
+      </button>
+
+      {open && (
+        <>
+          <div className="user-menu-overlay" onClick={() => setOpen(false)} />
+          <div className="user-menu-dropdown">
+            <div className="user-menu-info">
+              <p className="user-menu-name">{displayName}</p>
+              <p className="user-menu-email">{user.email}</p>
+            </div>
+            <hr className="user-menu-divider" />
+            <button
+              className="user-menu-item"
+              onClick={() => { setShowProfile(true); setOpen(false) }}
+            >
+              プロフィールを編集
+            </button>
+            <button className="user-menu-item user-menu-item--logout" onClick={onLogout}>
+              ログアウト
+            </button>
+          </div>
+        </>
+      )}
+
+      {showProfile && (
+        <UserProfileModal
+          user={user}
+          onClose={() => setShowProfile(false)}
+          onUpdated={onUserUpdated}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/user/UserProfileModal.css
+++ b/frontend/src/components/user/UserProfileModal.css
@@ -1,0 +1,148 @@
+.profile-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.profile-modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 28px 32px;
+  width: 340px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+}
+
+.profile-modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #222;
+  align-self: flex-start;
+}
+
+/* アバターアップロード */
+.avatar-upload-label {
+  position: relative;
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  cursor: pointer;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e8e4d8;
+  flex-shrink: 0;
+}
+
+.avatar-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatar-placeholder {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #888;
+}
+
+.avatar-upload-hint {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+  border-radius: 50%;
+}
+
+.avatar-upload-label:hover .avatar-upload-hint {
+  opacity: 1;
+}
+
+/* フォーム */
+.profile-field {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-label {
+  font-size: 0.82rem;
+  color: #666;
+  font-weight: 500;
+}
+
+.profile-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d0cbbf;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #222;
+  background: #fff;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.profile-input:focus {
+  border-color: #2c5f2e;
+}
+
+/* ボタン */
+.profile-modal-actions {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  justify-content: flex-end;
+}
+
+.profile-btn-cancel {
+  padding: 8px 16px;
+  border: 1px solid #d0cbbf;
+  border-radius: 6px;
+  background: #fff;
+  color: #555;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.profile-btn-cancel:hover {
+  background-color: #f5f0e8;
+}
+
+.profile-btn-save {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  background: #2c5f2e;
+  color: #fff;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.profile-btn-save:hover:not(:disabled) {
+  background-color: #245024;
+}
+
+.profile-btn-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/user/UserProfileModal.jsx
+++ b/frontend/src/components/user/UserProfileModal.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { supabase } from '../../lib/supabase'
+import api from '../../lib/api'
+import './UserProfileModal.css'
+
+export default function UserProfileModal({ user, onClose, onUpdated }) {
+  const [name, setName] = useState(
+    user.user_metadata?.display_name || user.user_metadata?.full_name || ''
+  )
+  const [avatarFile, setAvatarFile] = useState(null)
+  const [previewUrl, setPreviewUrl] = useState(user.user_metadata?.avatar_url || null)
+  const [saving, setSaving] = useState(false)
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    setAvatarFile(file)
+    setPreviewUrl(URL.createObjectURL(file))
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      let avatarUrl = user.user_metadata?.avatar_url
+
+      if (avatarFile) {
+        const formData = new FormData()
+        formData.append('file', avatarFile)
+        const res = await api.post('/users/me/avatar', formData)
+        avatarUrl = res.data.avatar_url
+      }
+
+      await supabase.auth.updateUser({
+        data: { display_name: name.trim(), avatar_url: avatarUrl }
+      })
+
+      await onUpdated()
+      onClose()
+    } catch {
+      // エラー時は何もしない
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="profile-modal-overlay" onClick={onClose}>
+      <div className="profile-modal" onClick={(e) => e.stopPropagation()}>
+        <h2 className="profile-modal-title">プロフィールを編集</h2>
+
+        <label className="avatar-upload-label">
+          {previewUrl
+            ? <img src={previewUrl} alt="avatar" className="avatar-preview" />
+            : <span className="avatar-placeholder">{name?.[0]?.toUpperCase() || '?'}</span>
+          }
+          <div className="avatar-upload-hint">変更</div>
+          <input type="file" accept="image/*" onChange={handleAvatarChange} hidden />
+        </label>
+
+        <div className="profile-field">
+          <label className="profile-label">ユーザー名</label>
+          <input
+            className="profile-input"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="表示名を入力"
+          />
+        </div>
+
+        <div className="profile-modal-actions">
+          <button className="profile-btn-cancel" onClick={onClose}>キャンセル</button>
+          <button className="profile-btn-save" onClick={handleSave} disabled={saving}>
+            {saving ? '保存中...' : '保存'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -21,20 +21,6 @@
   letter-spacing: 0.05em;
 }
 
-.logout-btn {
-  padding: 6px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: 6px;
-  background: transparent;
-  color: #fff;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background-color 0.15s;
-}
-
-.logout-btn:hover {
-  background-color: rgba(255, 255, 255, 0.15);
-}
 
 .home-main {
   flex: 1;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import Book from '../components/book/Book'
 import TagFilter from '../components/TagFilter'
 import UploadModal from '../components/upload/UploadModal'
 import ClipDetailModal from '../components/clip/ClipDetailModal'
+import UserMenu from '../components/user/UserMenu'
 import './Home.css'
 
 export default function Home() {
@@ -46,15 +47,20 @@ export default function Home() {
     navigate('/login')
   }
 
+  const refreshUser = async () => {
+    const { data: { user: updated } } = await supabase.auth.getUser()
+    setUser(updated)
+  }
+
   if (!user) return null
 
   return (
     <div className="home">
       <header className="home-header">
         <h1 className="home-title">Scrappa</h1>
-        <div style={{ display: 'flex', gap: '8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           <button className="upload-btn" onClick={() => setShowUpload(true)}>+ アップロード</button>
-          <button className="logout-btn" onClick={handleLogout}>ログアウト</button>
+          <UserMenu user={user} onLogout={handleLogout} onUserUpdated={refreshUser} />
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

- ヘッダーのログアウトボタンをユーザーアバター＋ドロップダウンメニューに置き換え
- メニューからユーザー名・プロフィール画像の編集とログアウトが可能

## Changes

**Frontend**
- `UserMenu.jsx/css`: アバターボタン＋ドロップダウン（透明オーバーレイで外側クリック閉じる）
- `UserProfileModal.jsx/css`: ユーザー名・アバター画像の編集モーダル
- `Home.jsx`: UserMenu を組み込み、`refreshUser` で保存後に user state を再取得

**Backend**
- `routers/users.py`: `POST /users/me/avatar` — S3 へのアバターアップロード（200×200px）
- `services/image.py`: `process_avatar_image()` 関数を追加
- `main.py`: users ルーターを登録

## Test plan

- [ ] ヘッダー右端にアバター（またはイニシャル）が表示される
- [ ] アバタークリックでドロップダウンが開く
- [ ] 外側クリックでドロップダウンが閉じる
- [ ] 「ログアウト」でログアウトできる
- [ ] 「プロフィールを編集」でモーダルが開く
- [ ] ユーザー名を変更して保存 → ドロップダウンの表示名が更新される
- [ ] アバター画像を選択してプレビューが表示される
- [ ] 保存後アバターが更新される

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)