### PR TITLE
feat: 通知機能・フレンドブックのBook形式表示・いいねをBookに統合

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import clips, tags, users, friends
+from app.routers import clips, tags, users, friends, notifications
 
 app = FastAPI(
     title="Scrappa API",
@@ -25,6 +25,7 @@ app.include_router(clips.router, prefix="/clips", tags=["clips"])
 app.include_router(tags.router, prefix="/tags", tags=["tags"])
 app.include_router(users.router, prefix="/users", tags=["users"])
 app.include_router(friends.router, prefix="/friends", tags=["friends"])
+app.include_router(notifications.router, prefix="/notifications", tags=["notifications"])
 
 @app.get("/")
 def root():

--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -285,6 +285,19 @@ async def delete_clip(
 async def like_clip(clip_id: str, user_id: str = Depends(get_current_user)):
     """クリップにいいねする（重複は無視）"""
     supabase.table("likes").upsert({"clip_id": clip_id, "user_id": user_id}).execute()
+
+    # クリップオーナーに通知を挿入（自分自身へは通知しない）
+    clip_res = supabase.table("clips").select("user_id").eq("id", clip_id).execute()
+    if clip_res.data:
+        owner_id = clip_res.data[0]["user_id"]
+        if owner_id != user_id:
+            supabase.table("notifications").insert({
+                "user_id": owner_id,
+                "type": "like",
+                "from_user_id": user_id,
+                "clip_id": clip_id,
+            }).execute()
+
     return {"ok": True}
 
 

--- a/backend/app/routers/friends.py
+++ b/backend/app/routers/friends.py
@@ -49,6 +49,13 @@ async def send_friend_request(
         "status": "pending",
     }).execute()
 
+    # フレンド申請通知を挿入
+    supabase.table("notifications").insert({
+        "user_id": body.to_user_id,
+        "type": "friend_request",
+        "from_user_id": user_id,
+    }).execute()
+
     return {"id": res.data[0]["id"]}
 
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, Response
+
+from app.db.supabase import supabase
+from app.middleware.auth import get_current_user
+
+router = APIRouter()
+
+
+@router.get("", response_model=dict)
+async def get_notifications(user_id: str = Depends(get_current_user)):
+    res = supabase.table("notifications") \
+        .select("id, type, from_user_id, clip_id, is_read, created_at") \
+        .eq("user_id", user_id) \
+        .order("created_at", desc=True) \
+        .limit(50) \
+        .execute()
+
+    notifications = res.data
+
+    # from_user プロフィールを一括取得
+    from_user_ids = list({n["from_user_id"] for n in notifications})
+    profiles_map = {}
+    if from_user_ids:
+        profiles_res = supabase.table("profiles") \
+            .select("id, display_name, avatar_url") \
+            .in_("id", from_user_ids) \
+            .execute()
+        profiles_map = {p["id"]: p for p in profiles_res.data}
+
+    result = []
+    for n in notifications:
+        result.append({
+            **n,
+            "from_user": profiles_map.get(
+                n["from_user_id"],
+                {"id": n["from_user_id"], "display_name": None, "avatar_url": None}
+            ),
+        })
+
+    unread_count = sum(1 for n in notifications if not n["is_read"])
+
+    return {"notifications": result, "unread_count": unread_count}
+
+
+@router.patch("/read", response_model=dict)
+async def mark_all_read(user_id: str = Depends(get_current_user)):
+    supabase.table("notifications") \
+        .update({"is_read": True}) \
+        .eq("user_id", user_id) \
+        .eq("is_read", False) \
+        .execute()
+    return {"ok": True}

--- a/backend/migrations/002_notifications.sql
+++ b/backend/migrations/002_notifications.sql
@@ -1,0 +1,31 @@
+-- 通知テーブル
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('friend_request', 'like')),
+  from_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  clip_id UUID REFERENCES clips(id) ON DELETE CASCADE,
+  is_read BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- RLS有効化
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+-- 自分宛ての通知のみ取得可能
+CREATE POLICY "Users can view own notifications"
+  ON notifications FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- 誰でも通知を挿入可能（バックエンドがサービスロールで操作）
+CREATE POLICY "Anyone can insert notifications"
+  ON notifications FOR INSERT
+  WITH CHECK (true);
+
+-- 自分宛ての通知のみ更新可能（既読化）
+CREATE POLICY "Users can update own notifications"
+  ON notifications FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Supabase Realtime を有効化
+ALTER PUBLICATION supabase_realtime ADD TABLE notifications;

--- a/frontend/src/components/book/Book.jsx
+++ b/frontend/src/components/book/Book.jsx
@@ -39,7 +39,7 @@ function SpreadNavigation({ current, total, onPrev, onNext }) {
   )
 }
 
-export default function Book({ clips, onClipClick, onEmptyClick }) {
+export default function Book({ clips, onClipClick, onEmptyClick, getLikeData }) {
   const [currentSpread, setCurrentSpread] = useState(0)
 
   const totalSpreads = Math.max(1, Math.ceil(clips.length / CLIPS_PER_SPREAD))
@@ -61,6 +61,7 @@ export default function Book({ clips, onClipClick, onEmptyClick }) {
           showEmptySlot={leftShowEmpty}
           onClipClick={onClipClick}
           onEmptyClick={onEmptyClick}
+          getLikeData={getLikeData}
         />
         <RingBinding />
         <Page
@@ -69,6 +70,7 @@ export default function Book({ clips, onClipClick, onEmptyClick }) {
           showEmptySlot={rightShowEmpty}
           onClipClick={onClipClick}
           onEmptyClick={onEmptyClick}
+          getLikeData={getLikeData}
         />
       </div>
       <SpreadNavigation

--- a/frontend/src/components/book/ClipCard.css
+++ b/frontend/src/components/book/ClipCard.css
@@ -71,3 +71,26 @@
   padding: 1px 5px;
   border-radius: 10px;
 }
+
+.clip-like-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(255, 255, 255, 0.88);
+  border: none;
+  border-radius: 10px;
+  padding: 2px 6px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  color: #aaa;
+  transition: background-color 0.1s, color 0.1s;
+  line-height: 1.4;
+}
+
+.clip-like-btn.liked {
+  color: #e74c3c;
+}
+
+.clip-like-btn:hover {
+  background: rgba(255, 255, 255, 1);
+}

--- a/frontend/src/components/book/ClipCard.jsx
+++ b/frontend/src/components/book/ClipCard.jsx
@@ -1,6 +1,6 @@
 import './ClipCard.css'
 
-export default function ClipCard({ clip, onOpen, onEmptyClick }) {
+export default function ClipCard({ clip, onOpen, onEmptyClick, likeData }) {
   if (!clip) {
     return (
       <div className="clip-card empty" onClick={onEmptyClick}>
@@ -10,7 +10,7 @@ export default function ClipCard({ clip, onOpen, onEmptyClick }) {
   }
 
   return (
-    <div className="clip-card" onClick={() => onOpen(clip)}>
+    <div className="clip-card" onClick={() => onOpen && onOpen(clip)}>
       <img src={clip.image_url} alt="" className="clip-image" />
       {clip.tags && clip.tags.length > 0 && (
         <div className="clip-tags">
@@ -18,6 +18,14 @@ export default function ClipCard({ clip, onOpen, onEmptyClick }) {
             <span key={tag} className="clip-tag">{tag}</span>
           ))}
         </div>
+      )}
+      {likeData && (
+        <button
+          className={`clip-like-btn ${likeData.liked ? 'liked' : ''}`}
+          onClick={(e) => { e.stopPropagation(); likeData.onToggle(clip) }}
+        >
+          ♥ {likeData.like_count}
+        </button>
       )}
     </div>
   )

--- a/frontend/src/components/book/Page.jsx
+++ b/frontend/src/components/book/Page.jsx
@@ -1,7 +1,7 @@
 import ClipCard from './ClipCard'
 import './Page.css'
 
-export default function Page({ clips = [], side, showEmptySlot, onClipClick, onEmptyClick }) {
+export default function Page({ clips = [], side, showEmptySlot, onClipClick, onEmptyClick, getLikeData }) {
   const paddedClips = showEmptySlot ? [...clips, null] : clips
 
   return (
@@ -13,6 +13,7 @@ export default function Page({ clips = [], side, showEmptySlot, onClipClick, onE
             clip={clip}
             onOpen={onClipClick}
             onEmptyClick={onEmptyClick}
+            likeData={clip && getLikeData ? getLikeData(clip) : undefined}
           />
         ))}
       </div>

--- a/frontend/src/components/friends/FriendBookModal.jsx
+++ b/frontend/src/components/friends/FriendBookModal.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import api from '../../lib/api'
+import Book from '../book/Book'
 import './FriendBookModal.css'
 
 export default function FriendBookModal({ friend, onClose }) {
@@ -12,7 +13,7 @@ export default function FriendBookModal({ friend, onClose }) {
       .finally(() => setLoading(false))
   }, [friend.id])
 
-  const toggleLike = async (clip) => {
+  const toggleLike = useCallback(async (clip) => {
     if (clip.liked) {
       await api.delete(`/clips/${clip.id}/likes`)
     } else {
@@ -23,7 +24,13 @@ export default function FriendBookModal({ friend, onClose }) {
         ? { ...c, liked: !c.liked, like_count: c.like_count + (c.liked ? -1 : 1) }
         : c
     ))
-  }
+  }, [])
+
+  const getLikeData = useCallback((clip) => ({
+    liked: clip.liked,
+    like_count: clip.like_count,
+    onToggle: toggleLike,
+  }), [toggleLike])
 
   const displayName = friend.display_name || 'ユーザー'
 
@@ -47,19 +54,7 @@ export default function FriendBookModal({ friend, onClose }) {
           ) : clips.length === 0 ? (
             <p className="friend-book-empty">クリップがありません</p>
           ) : (
-            <div className="friend-clips-grid">
-              {clips.map(clip => (
-                <div key={clip.id} className="friend-clip-card">
-                  <img src={clip.image_url} alt="" className="friend-clip-img" />
-                  <button
-                    className={`friend-clip-like ${clip.liked ? 'liked' : ''}`}
-                    onClick={() => toggleLike(clip)}
-                  >
-                    ♥ {clip.like_count}
-                  </button>
-                </div>
-              ))}
-            </div>
+            <Book clips={clips} getLikeData={getLikeData} />
           )}
         </div>
       </div>

--- a/frontend/src/components/notification/NotificationMenu.css
+++ b/frontend/src/components/notification/NotificationMenu.css
@@ -1,0 +1,122 @@
+.notif-menu {
+  position: relative;
+}
+
+.notif-btn {
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background-color 0.15s;
+  line-height: 1;
+}
+
+.notif-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.notif-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #e74c3c;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 1px 4px;
+  min-width: 14px;
+  text-align: center;
+  line-height: 1.4;
+  transform: translate(30%, -20%);
+}
+
+.notif-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+}
+
+.notif-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  z-index: 11;
+}
+
+.notif-header {
+  padding: 12px 16px 8px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #444;
+  border-bottom: 1px solid #f0ebe0;
+}
+
+.notif-empty {
+  text-align: center;
+  color: #aaa;
+  font-size: 0.85rem;
+  padding: 24px 16px;
+  margin: 0;
+}
+
+.notif-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #f5f0e8;
+  transition: background-color 0.1s;
+}
+
+.notif-item:last-child {
+  border-bottom: none;
+}
+
+.notif-item.unread {
+  background: #fdf6ec;
+}
+
+.notif-item:hover {
+  background: #faf7f2;
+}
+
+.notif-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.notif-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-text {
+  font-size: 0.82rem;
+  color: #333;
+  line-height: 1.4;
+}
+
+.notif-time {
+  font-size: 0.74rem;
+  color: #aaa;
+}

--- a/frontend/src/components/notification/NotificationMenu.jsx
+++ b/frontend/src/components/notification/NotificationMenu.jsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import './NotificationMenu.css'
+
+function timeAgo(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const min = Math.floor(diff / 60000)
+  if (min < 1) return 'たった今'
+  if (min < 60) return `${min}分前`
+  const hour = Math.floor(min / 60)
+  if (hour < 24) return `${hour}時間前`
+  return `${Math.floor(hour / 24)}日前`
+}
+
+export default function NotificationMenu({ notifications, unreadCount, onMarkAllRead }) {
+  const [open, setOpen] = useState(false)
+
+  const handleOpen = () => {
+    setOpen(true)
+    if (unreadCount > 0) onMarkAllRead()
+  }
+
+  const handleToggle = () => {
+    if (open) {
+      setOpen(false)
+    } else {
+      handleOpen()
+    }
+  }
+
+  return (
+    <div className="notif-menu">
+      <button className="notif-btn" onClick={handleToggle}>
+        🔔
+        {unreadCount > 0 && <span className="notif-badge">{unreadCount}</span>}
+      </button>
+
+      {open && (
+        <>
+          <div className="notif-overlay" onClick={() => setOpen(false)} />
+          <div className="notif-dropdown">
+            <div className="notif-header">通知</div>
+            {notifications.length === 0 ? (
+              <p className="notif-empty">通知はありません</p>
+            ) : (
+              <ul className="notif-list">
+                {notifications.map(n => (
+                  <li key={n.id} className={`notif-item ${n.is_read ? '' : 'unread'}`}>
+                    <span className="notif-icon">
+                      {n.type === 'like' ? '❤️' : '👥'}
+                    </span>
+                    <div className="notif-body">
+                      <span className="notif-text">
+                        <strong>{n.from_user?.display_name || 'ユーザー'}</strong>
+                        {n.type === 'like'
+                          ? ' があなたのクリップにいいねしました'
+                          : ' からフレンド申請が届きました'}
+                      </span>
+                      <span className="notif-time">{timeAgo(n.created_at)}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -1,0 +1,44 @@
+import { useState, useEffect, useCallback } from 'react'
+import api from '../lib/api'
+import { supabase } from '../lib/supabase'
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState([])
+  const [unreadCount, setUnreadCount] = useState(0)
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const res = await api.get('/notifications')
+      setNotifications(res.data.notifications)
+      setUnreadCount(res.data.unread_count)
+    } catch {
+      // 認証前など取得失敗時は無視
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchNotifications()
+
+    // Supabase Realtime: 新しい通知が届いたら再取得
+    const channel = supabase
+      .channel('notifications-realtime')
+      .on('postgres_changes', {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'notifications',
+      }, () => {
+        fetchNotifications()
+      })
+      .subscribe()
+
+    return () => supabase.removeChannel(channel)
+  }, [fetchNotifications])
+
+  const markAllRead = useCallback(async () => {
+    await api.patch('/notifications/read')
+    setNotifications(prev => prev.map(n => ({ ...n, is_read: true })))
+    setUnreadCount(0)
+  }, [])
+
+  return { notifications, unreadCount, markAllRead, refetch: fetchNotifications }
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,11 +4,13 @@ import { supabase } from '../lib/supabase'
 import api from '../lib/api'
 import { useClips } from '../hooks/useClips'
 import { useTags } from '../hooks/useTags'
+import { useNotifications } from '../hooks/useNotifications'
 import Book from '../components/book/Book'
 import TagFilter from '../components/TagFilter'
 import UploadModal from '../components/upload/UploadModal'
 import ClipDetailModal from '../components/clip/ClipDetailModal'
 import UserMenu from '../components/user/UserMenu'
+import NotificationMenu from '../components/notification/NotificationMenu'
 import FriendsPage from './FriendsPage'
 import './Home.css'
 
@@ -22,6 +24,7 @@ export default function Home() {
 
   const { clips, loading: clipsLoading, refetch } = useClips(selectedTag)
   const { tags, refetch: refetchTags } = useTags()
+  const { notifications, unreadCount, markAllRead } = useNotifications()
 
   const handleTagRenamed = (oldName, newName) => {
     refetchTags()
@@ -88,6 +91,11 @@ export default function Home() {
           </nav>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <NotificationMenu
+            notifications={notifications}
+            unreadCount={unreadCount}
+            onMarkAllRead={markAllRead}
+          />
           <UserMenu user={user} onLogout={handleLogout} onUserUpdated={refreshUser} />
         </div>
       </header>


### PR DESCRIPTION
## Summary

- フレンドのスクラップブックをフラットグリッドから `Book` コンポーネント（見開き形式）に変更
- いいねボタンを `ClipCard` の optional prop として統合し、Book ビュー内で表示可能に
- `notifications` テーブルを追加し、フレンド申請・いいね時に通知を挿入
- ヘッダーに 🔔 通知ベルアイコンを追加（未読数バッジ + ドロップダウン一覧）
- Supabase Realtime でリアルタイム通知受信

## 変更内容

### Backend
- `backend/migrations/002_notifications.sql` — `notifications` テーブル + RLS + Realtime 有効化
- `backend/app/routers/notifications.py` — `GET /notifications`, `PATCH /notifications/read`
- `backend/app/routers/clips.py` — `like_clip` でクリップオーナーへ通知挿入
- `backend/app/routers/friends.py` — `send_friend_request` で申請先へ通知挿入

### Frontend
- `ClipCard` — optional `likeData` prop（liked / like_count / onToggle）でいいねボタン表示
- `Page` / `Book` — `getLikeData` prop を伝搬
- `FriendBookModal` — Book コンポーネントを使用、`getLikeData` でいいね統合
- `useNotifications` フック — fetch + Supabase Realtime subscription
- `NotificationMenu` — ドロップダウン UI、開いた瞬間に全既読化

## マージ後の作業

Supabase SQL エディタで以下を実行してください：
```
backend/migrations/002_notifications.sql
```

## Test plan

- [ ] フレンドのスクラップブックが見開き本形式で表示される
- [ ] フレンドのクリップにいいねボタンが表示される
- [ ] いいねするとハート色が変わり、カウントが更新される
- [ ] いいね後、クリップオーナーの通知ベルに未読バッジが表示される
- [ ] フレンド申請時に相手の通知ベルにバッジが表示される
- [ ] 通知ベルを開くとドロップダウンに通知一覧が表示される
- [ ] 通知を開くと未読バッジが消える
- [ ] マイブックの既存クリップカードにいいねボタンが表示されない（既存機能への影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)