### PR TITLE
feat: いいね通知にクリップのサムネイル画像を表示

### DIFF
--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -27,6 +27,16 @@ async def get_notifications(user_id: str = Depends(get_current_user)):
             .execute()
         profiles_map = {p["id"]: p for p in profiles_res.data}
 
+    # いいね通知のクリップ画像を一括取得
+    clip_ids = [n["clip_id"] for n in notifications if n["type"] == "like" and n["clip_id"]]
+    clips_map = {}
+    if clip_ids:
+        clips_res = supabase.table("clips") \
+            .select("id, image_url") \
+            .in_("id", clip_ids) \
+            .execute()
+        clips_map = {c["id"]: c["image_url"] for c in clips_res.data}
+
     result = []
     for n in notifications:
         result.append({
@@ -35,6 +45,7 @@ async def get_notifications(user_id: str = Depends(get_current_user)):
                 n["from_user_id"],
                 {"id": n["from_user_id"], "display_name": None, "avatar_url": None}
             ),
+            "clip_image_url": clips_map.get(n["clip_id"]) if n["clip_id"] else None,
         })
 
     unread_count = sum(1 for n in notifications if not n["is_read"])

--- a/frontend/src/components/notification/NotificationMenu.css
+++ b/frontend/src/components/notification/NotificationMenu.css
@@ -120,3 +120,12 @@
   font-size: 0.74rem;
   color: #aaa;
 }
+
+.notif-clip-thumb {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border-radius: 5px;
+  flex-shrink: 0;
+  background: #e8e4d8;
+}

--- a/frontend/src/components/notification/NotificationMenu.jsx
+++ b/frontend/src/components/notification/NotificationMenu.jsx
@@ -57,6 +57,9 @@ export default function NotificationMenu({ notifications, unreadCount, onMarkAll
                       </span>
                       <span className="notif-time">{timeAgo(n.created_at)}</span>
                     </div>
+                    {n.type === 'like' && n.clip_image_url && (
+                      <img src={n.clip_image_url} alt="" className="notif-clip-thumb" />
+                    )}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary

いいね通知の行に、いいねされたクリップの画像（44×44px サムネイル）を表示する。

## 変更内容

### Backend — `notifications.py`
`GET /notifications` で `like` タイプの通知の `clip_id` からクリップ画像URLを一括取得し、`clip_image_url` フィールドとして返す（N+1 なし）。

### Frontend — `NotificationMenu.jsx` / `.css`
いいね通知かつ `clip_image_url` がある場合のみ、行の右端に 44×44px のサムネイルを表示する。

## Test plan

- [ ] いいね通知の行にクリップのサムネイル画像が表示される
- [ ] フレンド申請通知にはサムネイルが表示されない
- [ ] 画像が存在しない通知（`clip_image_url: null`）でもエラーにならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)