### PR TITLE
feat: ロゴタイトルクリックでマイブックに切り替え

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -74,7 +74,7 @@ export default function Home() {
     <div className="home">
       <header className="home-header">
         <div className="home-header-left">
-          <h1 className="home-title">Scrappa</h1>
+          <h1 className="home-title" onClick={() => setActiveTab('mybook')} style={{ cursor: 'pointer' }}>Scrappa</h1>
           <nav className="home-nav">
             <button
               className={`home-nav-btn ${activeTab === 'mybook' ? 'active' : ''}`}


### PR DESCRIPTION
## Summary

- ヘッダーの「Scrappa」タイトルをクリックするとマイブックタブに切り替わるようにした

## Test plan

- [ ] フレンドタブ表示中にロゴをクリックするとマイブックに切り替わる
- [ ] 既にマイブックの場合は何も変わらない（副作用なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)