### PR TITLE
feat: フレンドブックにタグフィルターとクリップ詳細表示を追加（issue #48）

### DIFF
--- a/frontend/src/components/friends/FriendBookModal.css
+++ b/frontend/src/components/friends/FriendBookModal.css
@@ -80,6 +80,49 @@
   flex: 1;
 }
 
+/* タグフィルター */
+.friend-tag-filter {
+  display: flex;
+  gap: 8px;
+  padding: 10px 16px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  background: #2c5f2e;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+}
+
+.friend-tag-filter::-webkit-scrollbar {
+  display: none;
+}
+
+.friend-tag-btn {
+  display: flex;
+  align-items: center;
+  padding: 4px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 20px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.friend-tag-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.friend-tag-btn.active {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+  font-weight: 600;
+}
+
 .friend-book-loading,
 .friend-book-empty {
   text-align: center;

--- a/frontend/src/components/friends/FriendBookModal.jsx
+++ b/frontend/src/components/friends/FriendBookModal.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useCallback } from 'react'
 import api from '../../lib/api'
 import Book from '../book/Book'
+import FriendClipDetailModal from './FriendClipDetailModal'
 import './FriendBookModal.css'
 
 export default function FriendBookModal({ friend, onClose }) {
   const [clips, setClips] = useState([])
   const [loading, setLoading] = useState(true)
+  const [selectedTag, setSelectedTag] = useState(null)
+  const [selectedClip, setSelectedClip] = useState(null)
 
   useEffect(() => {
     api.get(`/friends/${friend.id}/clips`)
@@ -32,6 +35,14 @@ export default function FriendBookModal({ friend, onClose }) {
     onToggle: toggleLike,
   }), [toggleLike])
 
+  // クリップから重複なくタグ一覧を生成
+  const friendTags = [...new Set(clips.flatMap(c => c.tags))]
+
+  // 選択タグでフィルタリング
+  const filteredClips = selectedTag
+    ? clips.filter(c => c.tags.includes(selectedTag))
+    : clips
+
   const displayName = friend.display_name || 'ユーザー'
 
   return (
@@ -48,16 +59,48 @@ export default function FriendBookModal({ friend, onClose }) {
           <button className="friend-book-close" onClick={onClose}>✕</button>
         </div>
 
+        {friendTags.length > 0 && (
+          <div className="friend-tag-filter">
+            <button
+              className={`friend-tag-btn ${selectedTag === null ? 'active' : ''}`}
+              onClick={() => setSelectedTag(null)}
+            >
+              すべて
+            </button>
+            {friendTags.map(tag => (
+              <button
+                key={tag}
+                className={`friend-tag-btn ${selectedTag === tag ? 'active' : ''}`}
+                onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+
         <div className="friend-book-body">
           {loading ? (
             <p className="friend-book-loading">読み込み中...</p>
           ) : clips.length === 0 ? (
             <p className="friend-book-empty">クリップがありません</p>
           ) : (
-            <Book clips={clips} getLikeData={getLikeData} />
+            <Book
+              key={selectedTag}
+              clips={filteredClips}
+              getLikeData={getLikeData}
+              onClipClick={setSelectedClip}
+            />
           )}
         </div>
       </div>
+
+      {selectedClip && (
+        <FriendClipDetailModal
+          clip={selectedClip}
+          onClose={() => setSelectedClip(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/friends/FriendClipDetailModal.jsx
+++ b/frontend/src/components/friends/FriendClipDetailModal.jsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import '../clip/ClipDetailModal.css'
+
+export default function FriendClipDetailModal({ clip, onClose }) {
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">クリップ</h2>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          <img src={clip.image_url} alt="クリップ" className="detail-image" />
+          {clip.tags?.length > 0 && (
+            <div className="tag-input-area">
+              <span className="tag-label">タグ</span>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                {clip.tags.map((tag) => (
+                  <span key={tag} className="tag-chip">{tag}</span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}


### PR DESCRIPTION
## Summary

- フレンドのタグで絞り込めるフィルターバーをモーダルヘッダー下に追加
- クリップをクリックすると読み取り専用の詳細モーダルが開く（編集・削除ボタンなし）
- タグ切り替え時に `key={selectedTag}` で Book を再マウントしてページを先頭にリセット

## 変更ファイル

- `FriendClipDetailModal.jsx`（新規）: 画像＋タグを表示する読み取り専用モーダル
- `FriendBookModal.jsx`: タグフィルター・クリップクリック処理を追加
- `FriendBookModal.css`: タグフィルターのスタイルを追加

## Test plan

- [ ] タグがあるフレンドのブックを開いたとき、フィルターバーが表示される
- [ ] タグなしのフレンドのブックを開いたとき、フィルターバーが表示されない
- [ ] タグをクリックすると絞り込まれ、もう一度クリックで解除される
- [ ] タグ切り替え時にページが1ページ目に戻る
- [ ] クリップをクリックすると詳細モーダルが開く
- [ ] 詳細モーダルに編集・削除ボタンがない
- [ ] いいねボタンが引き続き動作する

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)