### PR TITLE
feat: モバイルで横スワイプによるページ切り替え（issue #49）

### DIFF
--- a/frontend/src/components/book/Book.css
+++ b/frontend/src/components/book/Book.css
@@ -114,6 +114,8 @@
 
   .notebook-spread--mobile {
     justify-content: center;
+    user-select: none;
+    -webkit-user-drag: none;
   }
 
   .notebook-spread--mobile .page {

--- a/frontend/src/components/book/Book.jsx
+++ b/frontend/src/components/book/Book.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import Page from './Page'
 import { useIsMobile } from '../../hooks/useIsMobile'
+import { useSwipe } from '../../hooks/useSwipe'
 import './Book.css'
 
 const CLIPS_PER_PAGE = 12
@@ -63,9 +64,17 @@ export default function Book({ clips, onClipClick, onEmptyClick, getLikeData }) 
   // モバイル: 奇数ページ(0,2,4...)はリングが右、偶数ページ(1,3,5...)はリングが左
   const mobileRingOnRight = isMobile && currentSpread % 2 === 0
 
+  const swipeHandlers = useSwipe({
+    onSwipeLeft:  () => setCurrentSpread(s => Math.min(s + 1, totalSpreads - 1)),
+    onSwipeRight: () => setCurrentSpread(s => Math.max(s - 1, 0)),
+  })
+
   return (
     <div className="book-container">
-      <div className={`notebook-spread${isMobile ? ' notebook-spread--mobile' : ''}`}>
+      <div
+        className={`notebook-spread${isMobile ? ' notebook-spread--mobile' : ''}`}
+        {...(isMobile ? swipeHandlers : {})}
+      >
         {isMobile && !mobileRingOnRight && <RingBinding />}
         <Page
           clips={leftClips}

--- a/frontend/src/hooks/useSwipe.js
+++ b/frontend/src/hooks/useSwipe.js
@@ -1,0 +1,28 @@
+import { useRef, useCallback } from 'react'
+
+export function useSwipe({ onSwipeLeft, onSwipeRight, threshold = 50 }) {
+  const startX = useRef(null)
+  const startY = useRef(null)
+
+  const onTouchStart = useCallback((e) => {
+    startX.current = e.touches[0].clientX
+    startY.current = e.touches[0].clientY
+  }, [])
+
+  const onTouchEnd = useCallback((e) => {
+    if (startX.current === null) return
+    const deltaX = e.changedTouches[0].clientX - startX.current
+    const deltaY = e.changedTouches[0].clientY - startY.current
+
+    startX.current = null
+    startY.current = null
+
+    // 縦方向の移動が大きい場合はスクロールとみなしてスワイプ無視
+    if (Math.abs(deltaX) < Math.abs(deltaY)) return
+
+    if (deltaX < -threshold) onSwipeLeft?.()
+    else if (deltaX > threshold) onSwipeRight?.()
+  }, [onSwipeLeft, onSwipeRight, threshold])
+
+  return { onTouchStart, onTouchEnd }
+}


### PR DESCRIPTION
## Summary

- `useSwipe` カスタムフックを新規作成（`touchstart` / `touchend` でスワイプ検知）
- 縦スクロールとの競合を `Math.abs(deltaX) < Math.abs(deltaY)` で判定して回避
- モバイル時のみ `swipeHandlers` を `notebook-spread` に適用（PCには影響なし）
- `user-select: none` でスワイプ中の画像ドラッグ競合を防止

## Test plan

- [ ] 左スワイプで次のページに進む
- [ ] 右スワイプで前のページに戻る
- [ ] 最初のページで右スワイプしても何も起きない
- [ ] 最後のページで左スワイプしても何も起きない
- [ ] 縦スクロール中にページが誤って切り替わらない
- [ ] ナビゲーションボタン（← →）も引き続き動作する
- [ ] PC（768px以上）ではスワイプ処理が適用されない

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)