### PR TITLE
feat: 表紙の着せ替え機能を追加 (#61)

### DIFF
--- a/backend/app/models/friend.py
+++ b/backend/app/models/friend.py
@@ -13,3 +13,5 @@ class FriendRequestAction(BaseModel):
 class ProfileUpdate(BaseModel):
     display_name: Optional[str] = None
     avatar_url: Optional[str] = None
+    cover_color: Optional[str] = None
+    cover_title: Optional[str] = None

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -28,17 +28,28 @@ async def upload_avatar(
     return {"avatar_url": url}
 
 
+@router.get("/me", response_model=dict)
+async def get_my_profile(user_id: str = Depends(get_current_user)):
+    """自分のプロフィール（表紙設定を含む）を取得"""
+    res = supabase.table("profiles").select("*").eq("id", user_id).single().execute()
+    return res.data or {}
+
+
 @router.patch("/me", response_model=dict)
 async def update_profile(
     body: ProfileUpdate,
     user_id: str = Depends(get_current_user),
 ):
-    """profiles テーブルに表示名・アバターを同期（ユーザー検索に使用）"""
+    """profiles テーブルに表示名・アバター・表紙設定を同期"""
     upsert_data: dict = {"id": user_id}
     if body.display_name is not None:
         upsert_data["display_name"] = body.display_name
     if body.avatar_url is not None:
         upsert_data["avatar_url"] = body.avatar_url
+    if body.cover_color is not None:
+        upsert_data["cover_color"] = body.cover_color
+    if body.cover_title is not None:
+        upsert_data["cover_title"] = body.cover_title
 
     supabase.table("profiles").upsert(upsert_data).execute()
     return {"ok": True}

--- a/frontend/src/components/book/BookCover.css
+++ b/frontend/src/components/book/BookCover.css
@@ -1,7 +1,8 @@
 .cover-container {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
+  gap: 20px;
   padding: 32px 16px;
 }
 
@@ -13,13 +14,14 @@
 .cover-page {
   width: 300px;
   height: 480px;
-  background: #c8a882;
   border-radius: 0 8px 8px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 24px;
+  transition: background-color 0.3s;
+  box-sizing: border-box;
 }
 
 .cover-title {
@@ -30,12 +32,28 @@
   text-align: center;
   line-height: 1.6;
   word-break: break-all;
+  cursor: pointer;
+}
+
+.cover-title-input {
+  width: 100%;
+  margin: 0 0 24px;
+  padding: 6px 8px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #4a3728;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.5);
+  border: 2px solid rgba(74, 55, 40, 0.4);
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
 }
 
 .cover-open-btn {
   display: block;
   padding: 8px 28px;
-  background: #4a3728;
+  background: rgba(74, 55, 40, 0.75);
   color: #f5f0e8;
   border: none;
   border-radius: 6px;
@@ -46,5 +64,57 @@
 }
 
 .cover-open-btn:hover {
-  background: #6b5040;
+  background: rgba(74, 55, 40, 0.95);
+}
+
+/* カラー選択エリア */
+.cover-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.cover-color-btn {
+  padding: 7px 20px;
+  background: none;
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #555;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.cover-color-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #333;
+}
+
+/* カラーパレット */
+.color-picker {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.color-swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.1s;
+  padding: 0;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.color-swatch:hover {
+  transform: scale(1.15);
+}
+
+.color-swatch.selected {
+  border-color: #4a3728;
+  transform: scale(1.15);
 }

--- a/frontend/src/components/book/BookCover.jsx
+++ b/frontend/src/components/book/BookCover.jsx
@@ -1,16 +1,91 @@
+import { useState, useEffect } from 'react'
 import { RingBinding } from './Book'
 import './Book.css'
 import './BookCover.css'
 
-export default function BookCover({ userName, onOpen }) {
+const COVER_COLORS = [
+  { label: 'クラフト',     value: '#c8a882' },
+  { label: 'ベージュ',     value: '#e8dcc8' },
+  { label: 'オリーブ',     value: '#8b9d77' },
+  { label: 'テラコッタ',   value: '#c47a5a' },
+  { label: 'ネイビー',     value: '#3d5a80' },
+  { label: 'バーガンディ', value: '#7b2d42' },
+  { label: 'チャコール',   value: '#4a4a4a' },
+  { label: 'アイボリー',   value: '#f5f0e8' },
+]
+
+export default function BookCover({ userName, onOpen, coverColor, coverTitle, onColorChange, onTitleChange }) {
+  const defaultTitle = `${userName}のスクラップブック`
+  const displayTitle = coverTitle || defaultTitle
+
+  const [isEditingTitle, setIsEditingTitle] = useState(false)
+  const [editTitle, setEditTitle] = useState(displayTitle)
+  const [showColorPicker, setShowColorPicker] = useState(false)
+
+  useEffect(() => {
+    setEditTitle(coverTitle || defaultTitle)
+  }, [coverTitle, userName])
+
+  function handleTitleSave() {
+    setIsEditingTitle(false)
+    const trimmed = editTitle.trim()
+    if (trimmed && trimmed !== displayTitle) {
+      onTitleChange(trimmed)
+    } else {
+      setEditTitle(displayTitle)
+    }
+  }
+
   return (
     <div className="cover-container">
       <div className="cover-spread">
         <RingBinding />
-        <div className="cover-page">
-          <p className="cover-title">{userName}のスクラップブック</p>
+        <div className="cover-page" style={{ background: coverColor || '#c8a882' }}>
+          {isEditingTitle ? (
+            <input
+              className="cover-title-input"
+              value={editTitle}
+              onChange={e => setEditTitle(e.target.value)}
+              onBlur={handleTitleSave}
+              onKeyDown={e => { if (e.key === 'Enter') handleTitleSave() }}
+              autoFocus
+            />
+          ) : (
+            <p
+              className="cover-title"
+              onDoubleClick={() => setIsEditingTitle(true)}
+              title="ダブルクリックで編集"
+            >
+              {displayTitle}
+            </p>
+          )}
           <button className="cover-open-btn" onClick={onOpen}>開く</button>
         </div>
+      </div>
+
+      <div className="cover-actions">
+        <button
+          className="cover-color-btn"
+          onClick={() => setShowColorPicker(v => !v)}
+        >
+          表紙のカラーを選択
+        </button>
+        {showColorPicker && (
+          <div className="color-picker">
+            {COVER_COLORS.map(({ label, value }) => (
+              <button
+                key={value}
+                className={`color-swatch ${(coverColor || '#c8a882') === value ? 'selected' : ''}`}
+                style={{ background: value }}
+                title={label}
+                onClick={() => {
+                  onColorChange(value)
+                  setShowColorPicker(false)
+                }}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -22,6 +22,8 @@ export default function Home() {
   const [selectedTag, setSelectedTag] = useState(null)
   const [showUpload, setShowUpload] = useState(false)
   const [selectedClip, setSelectedClip] = useState(null)
+  const [coverColor, setCoverColor] = useState('#c8a882')
+  const [coverTitle, setCoverTitle] = useState(null)
   const navigate = useNavigate()
 
   const { clips, loading: clipsLoading, refetch } = useClips(selectedTag)
@@ -59,6 +61,25 @@ export default function Home() {
       api.patch('/users/me', { display_name: displayName, avatar_url: avatarUrl }).catch(() => {})
     }
   }, [user])
+
+  // 表紙カスタマイズ設定を取得
+  useEffect(() => {
+    if (!user) return
+    api.get('/users/me').then(({ data }) => {
+      if (data?.cover_color) setCoverColor(data.cover_color)
+      if (data?.cover_title) setCoverTitle(data.cover_title)
+    }).catch(() => {})
+  }, [user])
+
+  const handleCoverColorChange = async (color) => {
+    setCoverColor(color)
+    await api.patch('/users/me', { cover_color: color }).catch(() => {})
+  }
+
+  const handleCoverTitleChange = async (title) => {
+    setCoverTitle(title)
+    await api.patch('/users/me', { cover_title: title }).catch(() => {})
+  }
 
   const handleLogout = async () => {
     await supabase.auth.signOut()
@@ -122,7 +143,14 @@ export default function Home() {
 
       {activeTab === 'cover' ? (
         <main className="home-main">
-          <BookCover userName={user.user_metadata?.display_name || user.user_metadata?.full_name || user.email} onOpen={() => setActiveTab('mybook')} />
+          <BookCover
+            userName={user.user_metadata?.display_name || user.user_metadata?.full_name || user.email}
+            onOpen={() => setActiveTab('mybook')}
+            coverColor={coverColor}
+            coverTitle={coverTitle}
+            onColorChange={handleCoverColorChange}
+            onTitleChange={handleCoverTitleChange}
+          />
         </main>
       ) : activeTab === 'mybook' ? (
         <>


### PR DESCRIPTION
## Summary

- プリセットカラーパレット（8色）で表紙の色を変更できる機能を追加
- 表紙タイトルをダブルクリックでインライン編集できる機能を追加
- 設定は Supabase `profiles` テーブルに保存され、デバイスをまたいで引き継がれる
- 楽観的更新により色・タイトルの変更が即座にUIに反映される

## 変更ファイル

- `backend/app/models/friend.py` — `ProfileUpdate` モデルに `cover_color` / `cover_title` を追加
- `backend/app/routers/users.py` — `GET /users/me` を追加、`PATCH /users/me` を拡張
- `frontend/src/components/book/BookCover.jsx` — カラーピッカー・インライン編集を実装
- `frontend/src/components/book/BookCover.css` — カラーパレット・編集 input のスタイル追加
- `frontend/src/pages/Home.jsx` — 表紙設定の取得・保存ロジックを追加

## 事前作業（完了済み）

Supabase SQL Editor にて以下を実行済み:
```sql
ALTER TABLE profiles ADD COLUMN cover_color TEXT DEFAULT '#c8a882';
ALTER TABLE profiles ADD COLUMN cover_title TEXT;
```

## Test plan

- [ ] 「表紙のカラーを選択」ボタンをクリックするとカラーパレットが表示される
- [ ] 色を選択すると即座に表紙の色が変わる
- [ ] ページをリロードしても選択した色が保持される
- [ ] タイトルをダブルクリックするとインライン編集できる
- [ ] Enter またはフォーカスアウトでタイトルが保存される
- [ ] リロード後もタイトルが保持される
- [ ] マイブック・フレンドページへの切り替えが正常に動作する

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)