### PR TITLE
feat: クリップのメモ機能 + いいね数・いいねボタン追加 (#63)

### DIFF
--- a/backend/app/models/clip.py
+++ b/backend/app/models/clip.py
@@ -12,6 +12,7 @@ class ClipResponse(BaseModel):
     id: str = Field(description="クリップID（UUID）")
     image_url: str = Field(description="S3画像URL")
     tags: List[str] = Field(description="タグ名のリスト")
+    memo: Optional[str] = Field(default=None, description="メモ")
     page: int = Field(description="配置ページ番号")
     position: int = Field(description="ページ内の位置（0-11）")
     created_at: datetime = Field(description="作成日時")
@@ -19,5 +20,6 @@ class ClipResponse(BaseModel):
 class ClipUpdate(BaseModel):
     """クリップ更新リクエスト"""
     tags: Optional[List[str]] = None
+    memo: Optional[str] = None
     page: Optional[int] = None
     position: Optional[int] = None

--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -15,6 +15,7 @@ router = APIRouter()
 async def create_clip(
     file: UploadFile = File(..., description="画像ファイル（JPEG/PNG/WebP、10MB以下）"),
     tags: Optional[str] = Form(default="[]", description="タグ名のリスト（JSON配列文字列: '[\"ロゴ\", \"モノクロ\"]'）"),
+    memo: Optional[str] = Form(default="", description="メモ（省略可）"),
     page: Optional[int] = Form(default=None, description="配置ページ番号"),
     user_id: str = Depends(get_current_user),
 ):
@@ -71,6 +72,7 @@ async def create_clip(
         "image_url": image_url,
         "page": page,
         "position": position,
+        "memo": memo or None,
     }
     response = supabase.table("clips").insert(clip_data).execute()
     clip = response.data[0]
@@ -112,6 +114,7 @@ async def create_clip(
         id=clip["id"],
         image_url=clip["image_url"],
         tags=tag_names,
+        memo=clip.get("memo"),
         page=clip["page"],
         position=clip["position"],
         created_at=clip["created_at"]
@@ -205,10 +208,20 @@ async def get_clips(
             if name:
                 clip_tags_map.setdefault(row["clip_id"], []).append(name)
 
+        # likes を一括取得してクリップごとのいいね数を集計
+        likes_res = supabase.table("likes")\
+            .select("clip_id")\
+            .in_("clip_id", clip_ids)\
+            .execute()
+        likes_count_map: dict = {}
+        for row in likes_res.data:
+            likes_count_map[row["clip_id"]] = likes_count_map.get(row["clip_id"], 0) + 1
+
         for clip in clips_data:
             clips_with_tags.append({
                 **clip,
-                "tags": clip_tags_map.get(clip["id"], [])
+                "tags": clip_tags_map.get(clip["id"], []),
+                "likes_count": likes_count_map.get(clip["id"], 0),
             })
     
     # 総件数取得
@@ -238,6 +251,10 @@ async def update_clip(
     res = supabase.table("clips").select("id").eq("id", clip_id).eq("user_id", user_id).execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Clip not found")
+
+    # メモを更新
+    if body.memo is not None:
+        supabase.table("clips").update({"memo": body.memo or None}).eq("id", clip_id).execute()
 
     # 既存タグ関連を全削除してから再挿入（全差し替え方式）
     supabase.table("clip_tags").delete().eq("clip_id", clip_id).execute()

--- a/frontend/src/components/clip/ClipDetailModal.css
+++ b/frontend/src/components/clip/ClipDetailModal.css
@@ -177,6 +177,95 @@
   cursor: not-allowed;
 }
 
+/* 画像ラッパー（いいねボタン位置決め用） */
+.detail-image-wrap {
+  position: relative;
+}
+
+/* フレンドのクリップ詳細のいいねボタン */
+.detail-like-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.88);
+  border: none;
+  border-radius: 12px;
+  padding: 4px 10px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  color: #888;
+  transition: background-color 0.1s;
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.detail-like-btn:hover {
+  background: rgba(255, 255, 255, 1);
+}
+
+.detail-like-heart {
+  color: #bbb;
+  font-size: 0.95rem;
+  transition: color 0.15s;
+}
+
+.detail-like-btn.liked .detail-like-heart {
+  color: #e74c3c;
+}
+
+/* いいね数 */
+.clip-likes-count {
+  font-size: 0.85rem;
+  color: #e74c3c;
+  margin: -8px 0 0;
+  text-align: right;
+}
+
+/* メモ */
+.memo-area {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.memo-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.memo-input {
+  width: 100%;
+  font-size: 0.82rem;
+  color: #666;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 8px;
+  resize: vertical;
+  background: #fafaf8;
+  box-sizing: border-box;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.memo-input:focus {
+  outline: none;
+  border-color: #aaa;
+}
+
+/* フレンドのクリップ詳細のメモ（読み取り専用） */
+.clip-memo-readonly {
+  font-size: 0.82rem;
+  color: #aaa;
+  margin: 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  text-align: center;
+}
+
 /* 削除ボタン（赤系・左寄せ） */
 .delete-btn {
   padding: 8px 20px;

--- a/frontend/src/components/clip/ClipDetailModal.jsx
+++ b/frontend/src/components/clip/ClipDetailModal.jsx
@@ -7,6 +7,7 @@ import './ClipDetailModal.css'
 export default function ClipDetailModal({ clip, onClose, onUpdated, onDeleted }) {
   const [selectedTags, setSelectedTags] = useState(clip.tags ?? [])
   const [tagInput, setTagInput] = useState('')
+  const [memo, setMemo] = useState(clip.memo ?? '')
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState(null)
@@ -41,7 +42,7 @@ export default function ClipDetailModal({ clip, onClose, onUpdated, onDeleted })
     setSaving(true)
     setError(null)
     try {
-      await api.patch(`/clips/${clip.id}/`, { tags: selectedTags })
+      await api.patch(`/clips/${clip.id}/`, { tags: selectedTags, memo: memo || null })
       onUpdated()
       onClose()
     } catch (err) {
@@ -74,6 +75,9 @@ export default function ClipDetailModal({ clip, onClose, onUpdated, onDeleted })
         </div>
         <div className="modal-body">
           <img src={clip.image_url} alt="クリップ" className="detail-image" />
+          {clip.likes_count > 0 && (
+            <p className="clip-likes-count">❤️ {clip.likes_count}</p>
+          )}
 
           <div className="tag-input-area">
             <label className="tag-label">タグ</label>
@@ -101,6 +105,16 @@ export default function ClipDetailModal({ clip, onClose, onUpdated, onDeleted })
                   ))}
               </datalist>
             </div>
+          </div>
+          <div className="memo-area">
+            <label className="memo-label">メモ</label>
+            <textarea
+              className="memo-input"
+              value={memo}
+              onChange={e => setMemo(e.target.value)}
+              rows={1}
+              placeholder="メモを追加..."
+            />
           </div>
         </div>
         <div className="modal-footer detail-footer">

--- a/frontend/src/components/friends/FriendBookModal.jsx
+++ b/frontend/src/components/friends/FriendBookModal.jsx
@@ -99,6 +99,7 @@ export default function FriendBookModal({ friend, onClose }) {
         <FriendClipDetailModal
           clip={selectedClip}
           onClose={() => setSelectedClip(null)}
+          onToggleLike={toggleLike}
         />
       )}
     </div>

--- a/frontend/src/components/friends/FriendClipDetailModal.jsx
+++ b/frontend/src/components/friends/FriendClipDetailModal.jsx
@@ -1,8 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import '../clip/ClipDetailModal.css'
 
-export default function FriendClipDetailModal({ clip, onClose }) {
+export default function FriendClipDetailModal({ clip, onClose, onToggleLike }) {
+  const [liked, setLiked] = useState(clip.liked)
+  const [likeCount, setLikeCount] = useState(clip.like_count)
+
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') onClose()
@@ -11,15 +14,32 @@ export default function FriendClipDetailModal({ clip, onClose }) {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [onClose])
 
+  const handleLike = async () => {
+    const newLiked = !liked
+    setLiked(newLiked)
+    setLikeCount(c => c + (newLiked ? 1 : -1))
+    await onToggleLike(clip)
+  }
+
   return createPortal(
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-header">
-          <h2 className="modal-title">クリップ</h2>
+        <div className="modal-header" style={{ justifyContent: 'flex-end' }}>
           <button className="modal-close" onClick={onClose}>×</button>
         </div>
         <div className="modal-body">
-          <img src={clip.image_url} alt="クリップ" className="detail-image" />
+          <div className="detail-image-wrap">
+            <img src={clip.image_url} alt="クリップ" className="detail-image" />
+            <button
+              className={`detail-like-btn ${liked ? 'liked' : ''}`}
+              onClick={e => { e.stopPropagation(); handleLike() }}
+            >
+              <span className="detail-like-heart">♥</span> {likeCount}
+            </button>
+          </div>
+          {clip.memo && (
+            <p className="clip-memo-readonly">{clip.memo}</p>
+          )}
           {clip.tags?.length > 0 && (
             <div className="tag-input-area">
               <span className="tag-label">タグ</span>

--- a/frontend/src/components/upload/UploadModal.css
+++ b/frontend/src/components/upload/UploadModal.css
@@ -268,3 +268,36 @@
 .crop-confirm-btn:hover {
   background-color: #24512a;
 }
+
+/* メモ入力 */
+.memo-area {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.memo-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.memo-input {
+  width: 100%;
+  font-size: 0.82rem;
+  color: #666;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 8px;
+  resize: vertical;
+  background: #fafaf8;
+  box-sizing: border-box;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.memo-input:focus {
+  outline: none;
+  border-color: #aaa;
+}

--- a/frontend/src/components/upload/UploadModal.jsx
+++ b/frontend/src/components/upload/UploadModal.jsx
@@ -22,6 +22,7 @@ export default function UploadModal({ onClose, onUploaded }) {
 
   const [selectedTags, setSelectedTags] = useState([])
   const [tagInput, setTagInput] = useState('')
+  const [memo, setMemo] = useState('')
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState(null)
   const inputRef = useRef(null)
@@ -107,6 +108,7 @@ export default function UploadModal({ onClose, onUploaded }) {
       const formData = new FormData()
       formData.append('file', file)
       formData.append('tags', JSON.stringify(selectedTags))
+      formData.append('memo', memo)
       await api.post('/clips/', formData)
       onUploaded()
       onClose()
@@ -214,35 +216,47 @@ export default function UploadModal({ onClose, onUploaded }) {
             </div>
           )}
 
-          {/* タグ選択（フェーズ3のみ表示） */}
+          {/* タグ・メモ入力（フェーズ3のみ表示） */}
           {phase === 'preview' && (
-            <div className="tag-input-area">
-              <label className="tag-label">タグ</label>
-              <div className="tag-chips">
-                {selectedTags.map((tag) => (
-                  <span key={tag} className="tag-chip">
-                    {tag}
-                    <button className="tag-chip-remove" onClick={() => removeTag(tag)}>×</button>
-                  </span>
-                ))}
-                <input
-                  className="tag-input"
-                  type="text"
-                  list="tag-suggestions"
-                  value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
-                  onKeyDown={handleTagKeyDown}
-                  placeholder="タグを入力してEnter"
-                />
-                <datalist id="tag-suggestions">
-                  {existingTags
-                    .filter((t) => !selectedTags.includes(t.name))
-                    .map((t) => (
-                      <option key={t.id} value={t.name} />
-                    ))}
-                </datalist>
+            <>
+              <div className="tag-input-area">
+                <label className="tag-label">タグ</label>
+                <div className="tag-chips">
+                  {selectedTags.map((tag) => (
+                    <span key={tag} className="tag-chip">
+                      {tag}
+                      <button className="tag-chip-remove" onClick={() => removeTag(tag)}>×</button>
+                    </span>
+                  ))}
+                  <input
+                    className="tag-input"
+                    type="text"
+                    list="tag-suggestions"
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagKeyDown}
+                    placeholder="タグを入力してEnter"
+                  />
+                  <datalist id="tag-suggestions">
+                    {existingTags
+                      .filter((t) => !selectedTags.includes(t.name))
+                      .map((t) => (
+                        <option key={t.id} value={t.name} />
+                      ))}
+                  </datalist>
+                </div>
               </div>
-            </div>
+              <div className="memo-area">
+                <label className="memo-label">メモ</label>
+                <textarea
+                  className="memo-input"
+                  placeholder="メモを入力（任意）"
+                  value={memo}
+                  onChange={e => setMemo(e.target.value)}
+                  rows={1}
+                />
+              </div>
+            </>
           )}
         </div>
         <div className="modal-footer">


### PR DESCRIPTION
## Summary

- アップロード・詳細画面にメモ入力欄を追加（1行）
- クリップ詳細でいいね数を表示（❤️ N）
- フレンドのクリップ詳細に画像右下のいいねボタンを追加（グレー/赤の切り替え）
- フレンドのクリップ詳細: 画像→メモ（中央揃え）→タグの順に表示

## 事前作業（完了済み）

Supabase SQL Editor にて以下を実行済み:
```sql
ALTER TABLE clips ADD COLUMN memo TEXT;
```

## 変更ファイル

**Backend**
- `backend/app/models/clip.py` — `ClipResponse` / `ClipUpdate` に `memo` を追加
- `backend/app/routers/clips.py` — メモの保存・更新、`likes_count` のバッチ取得

**Frontend**
- `UploadModal.jsx/css` — メモ入力欄を追加
- `ClipDetailModal.jsx/css` — メモ編集・いいね数表示を追加
- `FriendClipDetailModal.jsx` — いいねボタン・メモ表示・レイアウト修正
- `FriendBookModal.jsx` — `onToggleLike` を詳細モーダルに渡す

## Test plan

- [ ] アップロード時にメモを入力して保存できる
- [ ] クリップ詳細でメモが表示・編集できる
- [ ] いいねが1件以上あるクリップ詳細に ❤️ N が表示される
- [ ] フレンドのクリップ詳細に画像右下のいいねボタンが表示される
- [ ] いいねボタンを押すとハートが赤になりカウントが増える
- [ ] 再度押すとグレーに戻りカウントが減る
- [ ] フレンドのクリップ詳細でメモが中央揃えで表示される（画像→メモ→タグの順）

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)