### PR TITLE
fix: フレンドタブのラベルが改行されないようにする

### DIFF
--- a/frontend/src/pages/FriendsPage.css
+++ b/frontend/src/pages/FriendsPage.css
@@ -24,6 +24,7 @@
   border-radius: 6px 6px 0 0;
   position: relative;
   transition: background-color 0.1s, color 0.1s;
+  white-space: nowrap;
 }
 
 .fp-tab:hover {


### PR DESCRIPTION
## Summary
- モバイル表示でフレンドタブの「ユーザー検索」「申請」が途中で改行される問題を修正

## 変更内容
- `.fp-tab` に `white-space: nowrap` を追加

## Test plan
- [ ] モバイル幅でフレンドタブを表示 → 「ユーザー検索」「申請」が1行で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)