### PR TITLE
feat: トップページ（ランディングページ）を追加

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import Login from './pages/Login'
+import LandingPage from './pages/LandingPage'
 import AuthCallback from './pages/AuthCallback'
 import Home from './pages/Home'
 
@@ -7,8 +7,9 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/home" element={<Home />} />
+        <Route path="/login" element={<Navigate to="/" replace />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -8,7 +8,7 @@ export default function AuthCallback() {
   useEffect(() => {
     supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session) {
-        navigate('/')
+        navigate('/home')
       }
     })
   }, [navigate])

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -46,7 +46,7 @@ export default function Home() {
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (!session) {
-        navigate('/login')
+        navigate('/')
       } else {
         setUser(session.user)
       }

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -1,0 +1,352 @@
+/* ─── 全体 ─── */
+.lp {
+  min-height: 100vh;
+  background-color: #f5f0e8;
+  color: #4a3728;
+  font-family: 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
+}
+
+/* ─── Hero ─── */
+.lp-hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 48px;
+  background-color: #f5f0e8;
+}
+
+.lp-notebook-cover {
+  display: flex;
+  width: 400px;
+  min-height: 520px;
+  background-color: #ede8d8;
+  border-radius: 4px 12px 12px 4px;
+  box-shadow: 6px 6px 24px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+
+.lp-cover-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 36px;
+  gap: 20px;
+}
+
+.lp-logo {
+  height: 100px;
+  width: auto;
+}
+
+.lp-catchcopy {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #4a3728;
+  text-align: center;
+  margin: 0;
+  line-height: 1.5;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.lp-desc {
+  font-size: 0.85rem;
+  line-height: 1.8;
+  color: #6b5344;
+  text-align: center;
+  margin: 0;
+  text-wrap: balance;
+}
+
+/* ─── Google ログインボタン ─── */
+.lp-google-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 24px;
+  background: #ffffff;
+  color: #333;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  transition: box-shadow 0.2s, transform 0.1s;
+  width: fit-content;
+}
+
+.lp-google-btn:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+}
+
+.lp-google-btn:active {
+  transform: translateY(0);
+}
+
+/* ─── セクション共通 ─── */
+.lp-section {
+  padding: 72px 48px;
+}
+
+.lp-section:nth-child(even) {
+  background-color: #ede8d8;
+}
+
+.lp-section-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  text-align: center;
+  margin: 0 0 12px;
+  color: #4a3728;
+}
+
+.lp-section-sub {
+  text-align: center;
+  color: #6b5344;
+  line-height: 1.8;
+  margin: 0 0 40px;
+  font-size: 0.95rem;
+}
+
+/* ─── Concept ─── */
+.lp-concept-grid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.lp-concept-card {
+  flex: 1;
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 12px rgba(74, 55, 40, 0.08);
+  text-align: center;
+}
+
+.lp-concept-card ul {
+  display: inline-block;
+  text-align: left;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lp-concept-card li {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+  padding: 5px 0;
+  font-size: 0.92rem;
+  color: #4a3728;
+  line-height: 1.5;
+}
+
+.lp-concept-card li::before {
+  content: '・';
+  flex-shrink: 0;
+  color: #2c5f2e;
+}
+
+.lp-concept-label {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.lp-concept-label.analog {
+  background: #c8a882;
+  color: #fff;
+}
+
+.lp-concept-label.digital {
+  background: #2c5f2e;
+  color: #fff;
+}
+
+.lp-concept-plus {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #c8a882;
+  flex-shrink: 0;
+}
+
+/* ─── Features ─── */
+.lp-features-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  max-width: 800px;
+  margin: 40px auto 0;
+}
+
+.lp-feature-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 12px rgba(74, 55, 40, 0.08);
+}
+
+.lp-feature-num {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #c8a882;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.lp-feature-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 10px;
+  color: #4a3728;
+}
+
+.lp-feature-body {
+  font-size: 0.88rem;
+  line-height: 1.7;
+  color: #6b5344;
+  margin: 0;
+}
+
+/* ─── How to use ─── */
+.lp-howto {
+  background-color: #ede8d8;
+}
+
+.lp-steps {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 560px;
+  margin: 40px auto 0;
+  gap: 0;
+}
+
+.lp-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px 24px;
+  width: 100%;
+  box-shadow: 0 2px 12px rgba(74, 55, 40, 0.08);
+}
+
+.lp-step-num {
+  width: 36px;
+  height: 36px;
+  background: #2c5f2e;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.lp-step-body {
+  flex: 1;
+  text-align: center;
+}
+
+.lp-step-body h3 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: #4a3728;
+}
+
+.lp-step-body p {
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: #6b5344;
+  margin: 0;
+}
+
+.lp-step-arrow {
+  font-size: 1.2rem;
+  color: #c8a882;
+  padding: 6px 0;
+}
+
+/* ─── CTA ─── */
+.lp-cta {
+  padding: 80px 48px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+}
+
+.lp-cta-copy {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #4a3728;
+  margin: 0;
+}
+
+/* ─── Footer ─── */
+.lp-footer {
+  background: #2c5f2e;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+  padding: 16px;
+  font-size: 0.8rem;
+}
+
+.lp-footer p {
+  margin: 0;
+}
+
+/* ─── Mobile ─── */
+@media (max-width: 767px) {
+  .lp-hero {
+    padding: 40px 20px;
+  }
+
+  .lp-notebook-cover {
+    width: min(360px, calc(100vw - 40px));
+    min-height: 460px;
+  }
+
+  .lp-section {
+    padding: 48px 20px;
+  }
+
+  .lp-concept-grid {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .lp-concept-plus {
+    font-size: 1.4rem;
+    padding: 0;
+  }
+
+  .lp-features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lp-cta {
+    padding: 56px 20px;
+  }
+}

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,0 +1,176 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '../lib/supabase'
+import headerLogo from '../assets/headerlogo.png'
+import { RingBinding } from '../components/book/Book'
+import '../components/book/Book.css'
+import './LandingPage.css'
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" style={{ flexShrink: 0 }}>
+      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
+      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+    </svg>
+  )
+}
+
+export default function LandingPage() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) navigate('/home')
+    })
+  }, [navigate])
+
+  const handleGoogleLogin = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/auth/callback` }
+    })
+  }
+
+  return (
+    <div className="lp">
+
+      {/* ── Hero ── */}
+      <section className="lp-hero">
+        <div className="lp-notebook-cover">
+          <RingBinding />
+          <div className="lp-cover-content">
+            <img src={headerLogo} alt="Scrappa" className="lp-logo" />
+            <p className="lp-catchcopy">切り取って、集めて、私になる。</p>
+            <p className="lp-desc">日常の一部を切り取り、それらを一冊のノートに収集していくデジタルスクラップブック</p>
+            <button className="lp-google-btn" onClick={handleGoogleLogin}>
+              <GoogleIcon />
+              Google でログイン
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Concept ── */}
+      <section className="lp-section lp-concept">
+        <h2 className="lp-section-title">アナログの温かさ × デジタルの便利さ</h2>
+        <p className="lp-section-sub">
+          かつて雑誌やチラシの切り抜きをノートに貼って収集していたように、<br />
+          スマホで撮った日常の写真を切り取り、一冊のノートに収集していく。
+        </p>
+        <div className="lp-concept-grid">
+          <div className="lp-concept-card">
+            <div className="lp-concept-label analog">アナログ</div>
+            <ul>
+              <li>リングノートの質感</li>
+              <li>写真を切り抜く感覚</li>
+              <li>ページをめくる体験</li>
+              <li>自分だけのノートに育てる</li>
+            </ul>
+          </div>
+          <div className="lp-concept-plus">×</div>
+          <div className="lp-concept-card">
+            <div className="lp-concept-label digital">デジタル</div>
+            <ul>
+              <li>スマホで即保存</li>
+              <li>正方形トリミング</li>
+              <li>いつでも見返せる</li>
+              <li>フレンドとゆるく共有</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Features ── */}
+      <section className="lp-section lp-features">
+        <h2 className="lp-section-title">Scrappaでできること</h2>
+        <div className="lp-features-grid">
+          <div className="lp-feature-card">
+            <div className="lp-feature-num">01</div>
+            <h3 className="lp-feature-title">記憶の蓄積</h3>
+            <p className="lp-feature-body">
+              写真全体ではなく「気になった部分だけ」を切り取り、それらを蓄積していく。
+              ページをめくるたびに、あのとき・あの場所・あの記憶が戻ってくる。
+            </p>
+          </div>
+          <div className="lp-feature-card">
+            <div className="lp-feature-num">02</div>
+            <h3 className="lp-feature-title">自分のコレクション</h3>
+            <p className="lp-feature-body">
+              テーマを決めて収集できる。集まるほどに達成感があり、自分だけのブックが育っていく感覚。
+              コレクションとしての楽しさもScrappaの魅力の一つ。
+            </p>
+          </div>
+          <div className="lp-feature-card">
+            <div className="lp-feature-num">03</div>
+            <h3 className="lp-feature-title">偶発的な発見</h3>
+            <p className="lp-feature-body">
+              収集してきたクリップ同士に、関係性・共通点が見えてくる。
+              その偶発的な発見が、自分の感性や好きを知るきっかけになる。
+            </p>
+          </div>
+          <div className="lp-feature-card">
+            <div className="lp-feature-num">04</div>
+            <h3 className="lp-feature-title">フレンドとゆるく共有</h3>
+            <p className="lp-feature-body">
+              フレンドのブックをのぞいたり、いいねを送ったり。
+              発信ではなく「見せ合う」ゆるいつながり。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── How to use ── */}
+      <section className="lp-section lp-howto">
+        <h2 className="lp-section-title">使い方</h2>
+        <div className="lp-steps">
+          <div className="lp-step">
+            <div className="lp-step-num">1</div>
+            <div className="lp-step-body">
+              <h3>気になるものを撮る</h3>
+              <p>日常生活の中で目に入ったお菓子のパッケージ、カフェのインテリア、気になるロゴ。なんでもOK。</p>
+            </div>
+          </div>
+          <div className="lp-step-arrow">↓</div>
+          <div className="lp-step">
+            <div className="lp-step-num">2</div>
+            <div className="lp-step-body">
+              <h3>気になる部分だけトリミング</h3>
+              <p>写真の一部分だけを正方形に切り取る。</p>
+            </div>
+          </div>
+          <div className="lp-step-arrow">↓</div>
+          <div className="lp-step">
+            <div className="lp-step-num">3</div>
+            <div className="lp-step-body">
+              <h3>スクラップブックに保存</h3>
+              <p>自分だけのスクラップブックに収集したクリップが蓄積されていく。整理は不要。</p>
+            </div>
+          </div>
+          <div className="lp-step-arrow">↓</div>
+          <div className="lp-step">
+            <div className="lp-step-num">4</div>
+            <div className="lp-step-body">
+              <h3>見返して、自分を見つける</h3>
+              <p>ふと見返したとき、集めたものから自分の感性や好きが見えてくる。</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <section className="lp-cta">
+        <p className="lp-cta-copy">自分だけのスクラップブックを作ろう</p>
+        <button className="lp-google-btn" onClick={handleGoogleLogin}>
+          <GoogleIcon />
+          Google でログイン
+        </button>
+      </section>
+
+      <footer className="lp-footer">
+        <p>© 2026 Scrappa</p>
+      </footer>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- ノート表紙デザインのHeroセクション（RingBinding流用・ベージュ背景・ロゴ・キャッチコピー・Googleログインボタン）を持つランディングページを新規作成
- Concept / Features / How-to-use / CTA の5セクション構成
- ルーティングを再編成: `/` → LandingPage、`/home` → Home、`/login` → `/` リダイレクト
- 未認証ユーザーのリダイレクト先を `/` に統一

## Test plan

- [ ] 未ログイン状態で `/` にアクセス → ランディングページが表示される
- [ ] ログイン済みで `/` にアクセス → `/home` にリダイレクトされる
- [ ] Googleログインボタンを押す → OAuth フローが開始される
- [ ] ログイン完了後 → `/home` にリダイレクトされる
- [ ] `/login` にアクセス → `/` にリダイレクトされる
- [ ] モバイルで表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)