### PR TITLE
feat: ローディング画面にページめくりアニメーションを追加

### DIFF
--- a/frontend/src/components/LoadingScreen.css
+++ b/frontend/src/components/LoadingScreen.css
@@ -1,0 +1,84 @@
+/* ─── 画面全体 ─── */
+.loading-screen {
+  min-height: 100vh;
+  background-color: #f5f0e8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+/* ─── ノート全体（リング + ページ） ─── */
+.loading-book {
+  display: flex;
+  align-items: stretch;
+  height: 400px;
+  filter: drop-shadow(0 6px 24px rgba(0, 0, 0, 0.18));
+}
+
+/* ─── ページ群のラッパー ─── */
+.loading-pages {
+  position: relative;
+  width: 250px;
+  perspective: 600px;
+}
+
+/* ─── ページ共通 ─── */
+.loading-page {
+  position: absolute;
+  inset: 0;
+  background-color: #F5F2E8;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 27px,
+      rgba(0, 0, 0, 0.042) 27px,
+      rgba(0, 0, 0, 0.042) 28px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 27px,
+      rgba(0, 0, 0, 0.022) 27px,
+      rgba(0, 0, 0, 0.022) 28px
+    );
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 0 4px 4px 0;
+  transform-origin: left center;
+  animation: page-flip 1.6s ease-in-out infinite;
+}
+
+/* ─── ページめくりアニメーション ─── */
+@keyframes page-flip {
+  0%   { transform: rotateY(0deg);    opacity: 1; }
+  45%  { transform: rotateY(-90deg);  opacity: 0.6; }
+  90%  { transform: rotateY(-170deg); opacity: 0.1; }
+  100% { transform: rotateY(-180deg); opacity: 0; }
+}
+
+/* 各ページのディレイをずらしてパラパラ感を出す */
+.page-1 { animation-delay: 0s; }
+.page-2 { animation-delay: 0.4s; }
+.page-3 { animation-delay: 0.8s; }
+.page-4 { animation-delay: 1.2s; }
+
+/* ─── ローディングテキスト ─── */
+.loading-text {
+  font-size: 0.9rem;
+  color: #6b5344;
+  letter-spacing: 0.1em;
+  margin: 0;
+}
+
+.loading-text span {
+  display: inline-block;
+  animation: text-wave 0.9s ease-in-out infinite;
+}
+
+/* ─── 文字ウェーブアニメーション ─── */
+@keyframes text-wave {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-5px); }
+}

--- a/frontend/src/components/LoadingScreen.jsx
+++ b/frontend/src/components/LoadingScreen.jsx
@@ -1,0 +1,26 @@
+import { RingBinding } from './book/Book'
+import './book/Book.css'
+import './LoadingScreen.css'
+
+const TEXT = 'ローディング中'
+
+export default function LoadingScreen() {
+  return (
+    <div className="loading-screen">
+      <div className="loading-book">
+        <RingBinding />
+        <div className="loading-pages">
+          <div className="loading-page page-1" />
+          <div className="loading-page page-2" />
+          <div className="loading-page page-3" />
+          <div className="loading-page page-4" />
+        </div>
+      </div>
+      <p className="loading-text">
+        {TEXT.split('').map((char, i) => (
+          <span key={i} style={{ animationDelay: `${i * 0.1}s` }}>{char}</span>
+        ))}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
+import LoadingScreen from '../components/LoadingScreen'
 
 export default function AuthCallback() {
   const navigate = useNavigate()
@@ -13,9 +14,5 @@ export default function AuthCallback() {
     })
   }, [navigate])
 
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
-      <p>ログイン中...</p>
-    </div>
-  )
+  return <LoadingScreen />
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import { useClips } from '../hooks/useClips'
 import { useTags } from '../hooks/useTags'
 import { useNotifications } from '../hooks/useNotifications'
 import Book from '../components/book/Book'
+import LoadingScreen from '../components/LoadingScreen'
 import BookCover from '../components/book/BookCover'
 import TagFilter from '../components/TagFilter'
 import UploadModal from '../components/upload/UploadModal'
@@ -180,7 +181,7 @@ export default function Home() {
           />
           <main className="home-main">
             {clipsLoading ? (
-              <p className="loading-text">読み込み中...</p>
+              <LoadingScreen />
             ) : (
               <Book clips={clips} onClipClick={setSelectedClip} onEmptyClick={() => setShowUpload(true)} onShowCover={() => setActiveTab('cover')} onClipsReorder={handleClipsReorder} />
             )}


### PR DESCRIPTION
## Summary

- `LoadingScreen` コンポーネントを新規作成
  - `RingBinding` を使いマイブックと同じ縦長リングノートデザイン（高さ400px・幅250px、縦横比1.6:1）
  - `@keyframes page-flip` でページがパラパラめくれるループアニメーション
  - `@keyframes text-wave` で「ローディング中」文字がウェーブするアニメーション
  - `animation-delay` のスタガーで連続めくり感を表現
- `AuthCallback.jsx`: 「ログイン中...」テキストを `LoadingScreen` に差し替え
- `Home.jsx`: 「読み込み中...」テキストを `LoadingScreen` に差し替え

## Test plan

- [ ] Googleログインボタンを押す → `/auth/callback` でローディング画面が表示される
- [ ] ページめくりアニメーションがループしている
- [ ] 「ローディング中」の文字がウェーブしている
- [ ] ログイン完了後 → `/home` に自動遷移する
- [ ] `/home` のクリップ読み込み中もローディング画面が表示される
- [ ] モバイルでも表示が崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)