### PR TITLE
fix: ローディング画面のノート位置をマイブック画面と揃える

### DIFF
--- a/frontend/src/components/LoadingScreen.css
+++ b/frontend/src/components/LoadingScreen.css
@@ -1,11 +1,9 @@
 /* ─── 画面全体 ─── */
 .loading-screen {
-  min-height: 100vh;
-  background-color: #f5f0e8;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  padding-top: 24px; /* book-container と同じ padding */
   gap: 16px;
 }
 

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -14,5 +14,9 @@ export default function AuthCallback() {
     })
   }, [navigate])
 
-  return <LoadingScreen />
+  return (
+    <div style={{ minHeight: '100vh', backgroundColor: '#f5f0e8', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <LoadingScreen />
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

- `LoadingScreen` の `justify-content: center` を削除し、`padding-top: 24px`（`book-container` と同値）に変更
- Home でのクリップ読み込み中、ヘッダー〜ノートの距離がマイブック画面と一致するように修正
- `AuthCallback` はヘッダーがないため、全画面中央配置ラッパーで包み中央表示を維持

## Test plan

- [ ] `/home` のクリップ読み込み中にローディング画面が表示され、ノートの位置がマイブック表示時と揃っている
- [ ] Googleログイン後の `/auth/callback` でローディング画面が画面中央に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)