### PR TITLE
feat: モバイル・表紙・ローディングにノート画像を適用

### DIFF
--- a/frontend/src/components/LoadingScreen.css
+++ b/frontend/src/components/LoadingScreen.css
@@ -11,8 +11,18 @@
 .loading-book {
   display: flex;
   align-items: stretch;
+  gap: 0;
   height: 400px;
   filter: drop-shadow(0 6px 24px rgba(0, 0, 0, 0.18));
+}
+
+/* ─── リング画像 ─── */
+.loading-ring {
+  height: 100%;
+  width: auto;
+  display: block;
+  flex-shrink: 0;
+  margin-right: -50px;
 }
 
 /* ─── ページ群のラッパー ─── */

--- a/frontend/src/components/LoadingScreen.jsx
+++ b/frontend/src/components/LoadingScreen.jsx
@@ -1,14 +1,13 @@
-import { RingBinding } from './book/Book'
-import './book/Book.css'
 import './LoadingScreen.css'
 
 const TEXT = 'ローディング中'
+const RING_IMAGE = 'https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/notering.png'
 
 export default function LoadingScreen() {
   return (
     <div className="loading-screen">
       <div className="loading-book">
-        <RingBinding />
+        <img src={RING_IMAGE} alt="" className="loading-ring" />
         <div className="loading-pages">
           <div className="loading-page page-1" />
           <div className="loading-page page-2" />

--- a/frontend/src/components/book/Book.css
+++ b/frontend/src/components/book/Book.css
@@ -41,18 +41,6 @@
   display: none;
 }
 
-/* コイル製本 */
-.ring-binding {
-  width: 32px;
-  background: linear-gradient(to right, #bab8b4 0%, #dedad4 35%, #edeae4 50%, #dedad4 65%, #bab8b4 100%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-evenly;
-  padding: 10px 0;
-  z-index: 1;
-  position: relative;
-}
 
 /* コイルひとつ = 正面から見た螺旋の輪の断面 */
 .coil {
@@ -162,9 +150,30 @@
     justify-content: center;
     user-select: none;
     -webkit-user-drag: none;
+    filter: drop-shadow(0 4px 16px rgba(0, 0, 0, 0.15));
+    border-radius: 4px 8px 8px 4px;
   }
 
+  /* CSS リングをレイアウトから除外（画像のリングを使用） */
+  .notebook-spread--mobile .ring-binding {
+    display: none;
+  }
+
+  /* ページ背景を透明にして背景画像を見せる */
   .notebook-spread--mobile .page {
-    width: min(300px, calc(100vw - 24px));
+    width: min(400px, calc(100vw - 8px));
+    height: min(560px, calc((100vw - 8px) * 1.4));
+    background: transparent;
+  }
+
+  /* クリップを小さく・リング側に余白を確保 */
+  .notebook-spread--mobile-right .page-grid {
+    padding: 80px 80px 80px 50px;
+    gap: 8px;
+  }
+
+  .notebook-spread--mobile-left .page-grid {
+    padding: 90px 50px 80px 80px;
+    gap: 8px;
   }
 }

--- a/frontend/src/components/book/Book.jsx
+++ b/frontend/src/components/book/Book.jsx
@@ -8,6 +8,9 @@ import './Book.css'
 
 const CLIPS_PER_PAGE = 12
 
+const MOBILE_BG_RIGHT = 'https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/single_notebook_right.png'
+const MOBILE_BG_LEFT  = 'https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/single_notebook_left.png'
+
 export function RingBinding() {
   const coils = Array.from({ length: 34 })
   return (
@@ -111,8 +114,14 @@ export default function Book({ clips, onClipClick, onEmptyClick, getLikeData, on
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <div className="book-container">
         <div
-          className={`notebook-spread${isMobile ? ' notebook-spread--mobile' : ''}`}
+          className={`notebook-spread${isMobile ? ` notebook-spread--mobile notebook-spread--mobile-${mobileRingOnRight ? 'right' : 'left'}` : ''}`}
           {...(isMobile ? swipeHandlers : {})}
+          style={isMobile ? {
+            backgroundImage: `url('${mobileRingOnRight ? MOBILE_BG_RIGHT : MOBILE_BG_LEFT}')`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+          } : undefined}
         >
           {isMobile && !mobileRingOnRight && <RingBinding />}
           <Page

--- a/frontend/src/components/book/BookCover.css
+++ b/frontend/src/components/book/BookCover.css
@@ -13,7 +13,7 @@
   filter: drop-shadow(0 4px 16px rgba(0, 0, 0, 0.2));
   background-image: url('https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/ringnotebook-title.png');
   background-size: cover;
-  background-position: left center;
+  background-position: center center;
   background-repeat: no-repeat;
   border-radius: 4px 8px 8px 4px;
 }
@@ -28,7 +28,7 @@
 
 .cover-page {
   position: absolute;
-  left: 78px;
+  left: 25px;
   top: 0;
   right: 0;
   bottom: 0;
@@ -71,9 +71,9 @@
 .cover-open-btn {
   display: block;
   padding: 8px 28px;
-  background: rgba(74, 55, 40, 0.75);
-  color: #f5f0e8;
-  border: none;
+  background: rgba(240, 238, 238, 0.75);
+  color: #080703;
+  border: 1.5px solid rgba(5, 5, 5, 0.4);
   border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 600;
@@ -82,43 +82,15 @@
 }
 
 .cover-open-btn:hover {
-  background: rgba(74, 55, 40, 0.95);
+  background: rgba(207, 207, 207, 0.85);
 }
 
-/* カラー選択エリア */
+/* フォント選択エリア */
 .cover-actions {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 12px;
-}
-
-.cover-color-btn {
-  position: relative;
-  padding: 7px 20px;
-  background: none;
-  border: 1px solid #bbb;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  color: #555;
-  cursor: pointer;
-  transition: background-color 0.15s, color 0.15s;
-}
-
-.cover-color-btn:hover {
-  background: rgba(0, 0, 0, 0.06);
-  color: #333;
-}
-
-.cover-color-input {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  cursor: pointer;
-  border: none;
-  padding: 0;
 }
 
 /* フォント選択 */
@@ -149,4 +121,12 @@
   color: #4a3728;
   font-weight: 600;
   background: rgba(74, 55, 40, 0.06);
+}
+
+@media (max-width: 767px) {
+  .cover-spread {
+    width: min(420px, calc(100vw - 32px));
+    height: auto;
+    aspect-ratio: 420 / 480;
+  }
 }

--- a/frontend/src/components/book/BookCover.jsx
+++ b/frontend/src/components/book/BookCover.jsx
@@ -11,21 +11,16 @@ const COVER_FONTS = [
   { label: '筆記体',     value: 'Yuji Syuku' },
 ]
 
-export default function BookCover({ userName, onOpen, coverColor, coverTitle, coverFont, onColorChange, onTitleChange, onFontChange, readOnly = false }) {
+export default function BookCover({ userName, onOpen, coverTitle, coverFont, onTitleChange, onFontChange, readOnly = false }) {
   const defaultTitle = `${userName}のスクラップブック`
   const displayTitle = coverTitle || defaultTitle
 
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [editTitle, setEditTitle] = useState(displayTitle)
-  const [localColor, setLocalColor] = useState(coverColor || '#c8a882')
 
   useEffect(() => {
     setEditTitle(coverTitle || defaultTitle)
   }, [coverTitle, userName])
-
-  useEffect(() => {
-    setLocalColor(coverColor || '#c8a882')
-  }, [coverColor])
 
   function handleTitleSave() {
     setIsEditingTitle(false)
@@ -41,7 +36,7 @@ export default function BookCover({ userName, onOpen, coverColor, coverTitle, co
     <div className="cover-container">
       <div className="cover-spread">
         <RingBinding />
-        <div className="cover-page" style={{ background: localColor }}>
+        <div className="cover-page">
           {!readOnly && isEditingTitle ? (
             <input
               className="cover-title-input"
@@ -66,32 +61,20 @@ export default function BookCover({ userName, onOpen, coverColor, coverTitle, co
         </div>
       </div>
 
-      {!readOnly && (
+      {!readOnly && isEditingTitle && (
         <div className="cover-actions">
-          <label className="cover-color-btn">
-            表紙のカラーを選択
-            <input
-              type="color"
-              className="cover-color-input"
-              value={localColor}
-              onChange={e => setLocalColor(e.target.value)}
-              onBlur={e => onColorChange(e.target.value)}
-            />
-          </label>
-          {isEditingTitle && (
-            <div className="font-picker">
-              {COVER_FONTS.map(({ label, value }) => (
-                <button
-                  key={label}
-                  className={`font-option ${(coverFont || '') === value ? 'selected' : ''}`}
-                  style={{ fontFamily: value || 'inherit' }}
-                  onClick={() => onFontChange(value)}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
+          <div className="font-picker">
+            {COVER_FONTS.map(({ label, value }) => (
+              <button
+                key={label}
+                className={`font-option ${(coverFont || '') === value ? 'selected' : ''}`}
+                style={{ fontFamily: value || 'inherit' }}
+                onClick={() => onFontChange(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/book/Page.css
+++ b/frontend/src/components/book/Page.css
@@ -30,7 +30,6 @@
   border-radius: 0 8px 8px 0;
 }
 
-
 .page-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 24px;
+  padding: 20px 24px;
   background-color: #ede8d8;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -23,7 +23,6 @@ export default function Home() {
   const [selectedTag, setSelectedTag] = useState(null)
   const [showUpload, setShowUpload] = useState(false)
   const [selectedClip, setSelectedClip] = useState(null)
-  const [coverColor, setCoverColor] = useState('#c8a882')
   const [coverTitle, setCoverTitle] = useState(null)
   const [coverFont, setCoverFont] = useState('')
   const navigate = useNavigate()
@@ -68,16 +67,10 @@ export default function Home() {
   useEffect(() => {
     if (!user) return
     api.get('/users/me').then(({ data }) => {
-      if (data?.cover_color) setCoverColor(data.cover_color)
       if (data?.cover_title) setCoverTitle(data.cover_title)
       if (data?.cover_font) setCoverFont(data.cover_font)
     }).catch(() => {})
   }, [user])
-
-  const handleCoverColorChange = async (color) => {
-    setCoverColor(color)
-    await api.patch('/users/me', { cover_color: color }).catch(() => {})
-  }
 
   const handleCoverTitleChange = async (title) => {
     setCoverTitle(title)
@@ -162,10 +155,8 @@ export default function Home() {
           <BookCover
             userName={user.user_metadata?.display_name || user.user_metadata?.full_name || user.email}
             onOpen={() => setActiveTab('mybook')}
-            coverColor={coverColor}
             coverTitle={coverTitle}
             coverFont={coverFont}
-            onColorChange={handleCoverColorChange}
             onTitleChange={handleCoverTitleChange}
             onFontChange={handleCoverFontChange}
           />

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -16,18 +16,31 @@
 }
 
 .lp-notebook-cover {
+  position: relative;
   display: flex;
-  width: 400px;
+  width: 420px;
   min-height: 520px;
-  background-color: #ede8d8;
-  border-radius: 4px 12px 12px 4px;
-  box-shadow: 6px 6px 24px rgba(0, 0, 0, 0.3);
-  overflow: hidden;
+  background-image: url('https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/ringnotebook-title.png');
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+
+.lp-notebook-cover .ring-binding {
+  display: none;
+}
+
+.lp-notebook-cover .coil {
+  display: none;
 }
 
 
 .lp-cover-content {
-  flex: 1;
+  position: absolute;
+  left: 40px;
+  top: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -37,12 +50,12 @@
 }
 
 .lp-logo {
-  height: 100px;
+  height: 78px;
   width: auto;
 }
 
 .lp-catchcopy {
-  font-size: 1.15rem;
+  font-size: 0.95rem;
   font-weight: 700;
   color: #4a3728;
   text-align: center;
@@ -53,7 +66,7 @@
 }
 
 .lp-desc {
-  font-size: 0.85rem;
+  font-size: 0.60rem;
   line-height: 1.8;
   color: #6b5344;
   text-align: center;
@@ -324,7 +337,7 @@
   }
 
   .lp-notebook-cover {
-    width: min(360px, calc(100vw - 40px));
+    width: min(420px, calc(100vw - 32px));
     min-height: 460px;
   }
 

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -35,7 +35,6 @@ export default function LandingPage() {
 
   return (
     <div className="lp">
-
       {/* ── Hero ── */}
       <section className="lp-hero">
         <div className="lp-notebook-cover">
@@ -43,7 +42,10 @@ export default function LandingPage() {
           <div className="lp-cover-content">
             <img src={headerLogo} alt="Scrappa" className="lp-logo" />
             <p className="lp-catchcopy">切り取って、集めて、私になる。</p>
-            <p className="lp-desc">日常の一部を切り取り、それらを一冊のノートに収集していくデジタルスクラップブック</p>
+            <p className="lp-desc">
+              日常の一部を切り取り、それらを一冊の
+              <br />ノートに収集していくデジタルスクラップブック
+            </p>
             <button className="lp-google-btn" onClick={handleGoogleLogin}>
               <GoogleIcon />
               Google でログイン
@@ -54,9 +56,12 @@ export default function LandingPage() {
 
       {/* ── Concept ── */}
       <section className="lp-section lp-concept">
-        <h2 className="lp-section-title">アナログの温かさ × デジタルの便利さ</h2>
+        <h2 className="lp-section-title">
+          アナログの温かさ × デジタルの便利さ
+        </h2>
         <p className="lp-section-sub">
-          かつて雑誌やチラシの切り抜きをノートに貼って収集していたように、<br />
+          かつて雑誌やチラシの切り抜きをノートに貼って収集していたように、
+          <br />
           スマホで撮った日常の写真を切り取り、一冊のノートに収集していく。
         </p>
         <div className="lp-concept-grid">
@@ -129,7 +134,9 @@ export default function LandingPage() {
             <div className="lp-step-num">1</div>
             <div className="lp-step-body">
               <h3>気になるものを撮る</h3>
-              <p>日常生活の中で目に入ったお菓子のパッケージ、カフェのインテリア、気になるロゴ。なんでもOK。</p>
+              <p>
+                日常生活の中で目に入ったお菓子のパッケージ、カフェのインテリア、気になるロゴ。なんでもOK。
+              </p>
             </div>
           </div>
           <div className="lp-step-arrow">↓</div>
@@ -145,7 +152,9 @@ export default function LandingPage() {
             <div className="lp-step-num">3</div>
             <div className="lp-step-body">
               <h3>スクラップブックに保存</h3>
-              <p>自分だけのスクラップブックに収集したクリップが蓄積されていく。整理は不要。</p>
+              <p>
+                自分だけのスクラップブックに収集したクリップが蓄積されていく。整理は不要。
+              </p>
             </div>
           </div>
           <div className="lp-step-arrow">↓</div>
@@ -153,7 +162,9 @@ export default function LandingPage() {
             <div className="lp-step-num">4</div>
             <div className="lp-step-body">
               <h3>見返して、自分を見つける</h3>
-              <p>ふと見返したとき、集めたものから自分の感性や好きが見えてくる。</p>
+              <p>
+                ふと見返したとき、集めたものから自分の感性や好きが見えてくる。
+              </p>
             </div>
           </div>
         </div>
@@ -172,5 +183,5 @@ export default function LandingPage() {
         <p>© 2026 Scrappa</p>
       </footer>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary

- モバイルのマイブックページに奇数/偶数で異なるノート背景画像を適用
- 表紙（BookCover）にノート画像を適用し、カラー変更機能を削除
- ランディングページの Hero ノート表紙を画像に差し替え
- ローディング画面のリング部分を CSS → 実画像（notering.png）に置き換え

## Changes

- `Book.jsx/css`: モバイルページに `single_notebook_right/left.png` を inline style で適用、リングサイズ・クリップサイズ調整
- `BookCover.jsx/css`: `ringnotebook-title.png` を背景化、カラー変更機能削除、open ボタンに枠線・ホバー追加
- `LandingPage.jsx/css`: Hero のノート表紙を `ringnotebook-title.png` に差し替え
- `LoadingScreen.jsx/css`: `RingBinding` コンポーネント → `notering.png` 画像に置き換え、縦幅を揃える

## Test plan

- [ ] モバイルでマイブックのページ送り時に奇数/偶数でノート画像が切り替わることを確認
- [ ] 表紙画面でノート画像・タイトル・open ボタンが正しく表示されることを確認
- [ ] open ボタンのホバー時にグレーになることを確認
- [ ] ランディングページの Hero にノート画像が表示されることを確認
- [ ] ローディング画面でリング画像とページの縦幅が揃っていることを確認
- [ ] PC 版マイブックの動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)