### PR TITLE
OGP・Twitter cardメタタグを追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,22 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Scrappa</title>
+    <title>Scrappa | デジタルスクラップブック</title>
+
+    <!-- OGP -->
+    <meta property="og:title" content="Scrappa | デジタルスクラップブック" />
+    <meta property="og:description" content="撮影した写真の好きな部分だけを切り取り、ノートに貼るように保存することができるデジタルなスクラップブック" />
+    <meta property="og:image" content="https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/logo_OGP.jpg" />
+    <meta property="og:url" content="https://scrappaapp.vercel.app/" />
+    <meta property="og:site_name" content="Scrappa" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter / X -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Scrappa | デジタルスクラップブック" />
+    <meta name="twitter:description" content="撮影した写真の好きな部分だけを切り取り、ノートに貼るように保存することができるデジタルなスクラップブック" />
+    <meta name="twitter:image" content="https://scrappa-images.s3.ap-northeast-1.amazonaws.com/images/logo_OGP.jpg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=BIZ+UDGothic&family=BIZ+UDMincho&family=Hachi+Maru+Pop&family=Klee+One&family=M+PLUS+Rounded+1c&family=Noto+Sans+JP&family=Noto+Serif+JP&family=Reggae+One&family=Shippori+Mincho&family=Yuji+Syuku&family=Zen+Kurenaido&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- OGP（Open Graph Protocol）メタタグを追加
- Twitter / X カード用メタタグを追加
- ページタイトルを「Scrappa | デジタルスクラップブック」に更新

## 設定内容
| タグ | 値 |
|------|-----|
| `og:title` / `twitter:title` | Scrappa \| デジタルスクラップブック |
| `og:description` / `twitter:description` | 撮影した写真の好きな部分だけを切り取り... |
| `og:image` / `twitter:image` | S3 HTTPS URL（logo_OGP.jpg） |
| `og:url` | https://scrappaapp.vercel.app/ |
| `og:type` | website |
| `og:locale` | ja_JP |
| `twitter:card` | summary_large_image |

## Test plan
- [ ] SNSシェア時にタイトル・説明文・画像が正しく表示される
- [ ] [OGPデバッグツール](https://developers.facebook.com/tools/debug/)で確認
- [ ] [Twitter Card Validator](https://cards-dev.twitter.com/validator)で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)