### PR TITLE
feat: クリップ詳細画面に登録日を表示 #95

### DIFF
--- a/frontend/src/components/clip/ClipDetailModal.css
+++ b/frontend/src/components/clip/ClipDetailModal.css
@@ -62,12 +62,31 @@
 }
 
 /* クリップ画像（編集不可） */
+.detail-image-container {
+  position: relative;
+}
+
 .detail-image {
   width: 100%;
   max-height: 260px;
   object-fit: contain;
   border-radius: 8px;
   background-color: #f0ebe0;
+  display: block;
+}
+
+.detail-created-at {
+  display: block;
+  text-align: right;
+  margin-top: -18px;
+  padding-right: 8px;
+  font-size: 0.68rem;
+  color: #aaa;
+}
+
+/* マイブック: 日付はコンテナ内にあるので通常の余白で表示 */
+.detail-image-container .detail-created-at {
+  margin-top: 4px;
 }
 
 /* タグ入力エリア */

--- a/frontend/src/components/clip/ClipDetailModal.jsx
+++ b/frontend/src/components/clip/ClipDetailModal.jsx
@@ -84,7 +84,20 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
           <button className="modal-close" onClick={onClose}>×</button>
         </div>
         <div className="modal-body">
-          <img src={clip.image_url} alt="クリップ" className="detail-image" />
+          <div className="detail-image-container">
+            <img src={clip.image_url} alt="クリップ" className="detail-image" />
+            {clip.created_at && (
+              <span className="detail-created-at">
+                {(() => {
+                  const d = new Date(clip.created_at)
+                  const y = d.getFullYear()
+                  const m = String(d.getMonth() + 1).padStart(2, '0')
+                  const day = String(d.getDate()).padStart(2, '0')
+                  return `${y}.${m}.${day}`
+                })()}
+              </span>
+            )}
+          </div>
           {clip.likes_count > 0 && (
             <p className="clip-likes-count">❤️ {clip.likes_count}</p>
           )}

--- a/frontend/src/components/friends/FriendClipDetailModal.jsx
+++ b/frontend/src/components/friends/FriendClipDetailModal.jsx
@@ -37,6 +37,17 @@ export default function FriendClipDetailModal({ clip, onClose, onToggleLike }) {
               <span className="detail-like-heart">♥</span> {likeCount}
             </button>
           </div>
+          {clip.created_at && (
+            <span className="detail-created-at">
+              {(() => {
+                const d = new Date(clip.created_at)
+                const y = d.getFullYear()
+                const m = String(d.getMonth() + 1).padStart(2, '0')
+                const day = String(d.getDate()).padStart(2, '0')
+                return `${y}.${m}.${day}`
+              })()}
+            </span>
+          )}
           {clip.memo && (
             <p className="clip-memo-readonly">{clip.memo}</p>
           )}


### PR DESCRIPTION
## Summary

- マイブック・フレンドブック両方のクリップ詳細モーダルに登録日を追加
- 表示形式: `2026.04.01`（月・日はゼロ埋め）
- 文字色はグレー（`#aaa`）、画像と重ならない位置に配置
- マイブックは画像下に自然配置、フレンドブックはベージュ帯に引き上げ表示

## Test plan

- [ ] マイブックのクリップをクリック → 画像下右に登録日が表示される
- [ ] フレンドのブックのクリップをクリック → 登録日が表示される
- [ ] 表示形式が `2026.04.01` の形式になっている
- [ ] 画像とテキストが重ならない

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)