### PR TITLE
クリップ共有機能：チェキ風画像プレビュー＆ダウンロード

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
 from app.routers import clips, tags, users, friends, notifications, contact
+import httpx
 
 app = FastAPI(
     title="Scrappa API",
@@ -45,3 +47,21 @@ def health_check():
     ヘルスチェックエンドポイント
     """
     return {"status": "healthy", "version": "1.0.0"}
+
+@app.get("/image-proxy/")
+async def image_proxy(url: str):
+    """
+    S3画像をプロキシして返す（Canvas CORS対策）
+    """
+    allowed_host = "scrappa-images.s3.ap-northeast-1.amazonaws.com"
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    if parsed.hostname != allowed_host:
+        raise HTTPException(status_code=400, detail="Invalid image host")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=resp.status_code, detail="Failed to fetch image")
+        content_type = resp.headers.get("content-type", "image/jpeg")
+        return Response(content=resp.content, media_type=content_type)

--- a/frontend/src/components/clip/ClipDetailModal.css
+++ b/frontend/src/components/clip/ClipDetailModal.css
@@ -155,9 +155,15 @@
   border-top: 1px solid #eee;
 }
 
-/* 詳細モーダルのフッターは削除ボタン（左）と保存ボタン群（右）に分ける */
+/* 詳細モーダルのフッターは削除・共有ボタン（左）と保存ボタン群（右）に分ける */
 .detail-footer {
   justify-content: space-between;
+}
+
+.detail-footer-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .detail-footer-right {
@@ -283,6 +289,55 @@
   white-space: pre-wrap;
   word-break: break-word;
   text-align: center;
+}
+
+/* 共有プレビューモーダル */
+.share-preview-content {
+  background-color: #fff;
+  border-radius: 12px;
+  width: 480px;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.share-preview-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.share-preview-image {
+  width: 100%;
+  border-radius: 4px;
+  display: block;
+}
+
+/* 共有ボタン */
+.share-btn {
+  padding: 8px 20px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: none;
+  color: #555;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.share-btn:hover {
+  background-color: #f5f5f5;
+}
+
+.share-btn:disabled {
+  border-color: #aaa;
+  color: #aaa;
+  cursor: not-allowed;
 }
 
 /* 削除ボタン（赤系・左寄せ） */

--- a/frontend/src/components/clip/ClipDetailModal.jsx
+++ b/frontend/src/components/clip/ClipDetailModal.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useTags } from '../../hooks/useTags'
 import api from '../../lib/api'
 import * as guestStorage from '../../lib/guestStorage'
+import { generateShareImage } from '../../lib/generateShareImage'
 import './ClipDetailModal.css'
 
 export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpdated, onDeleted }) {
@@ -12,6 +13,8 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
   const [isPublic, setIsPublic] = useState(clip.is_public ?? true)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [sharing, setSharing] = useState(false)
+  const [previewUrl, setPreviewUrl] = useState(null)
   const [error, setError] = useState(null)
 
   const { tags: existingTags } = useTags(isGuest)
@@ -59,6 +62,31 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
     }
   }
 
+  const handleShare = async () => {
+    setSharing(true)
+    try {
+      const blob = await generateShareImage(clip)
+      const url = URL.createObjectURL(blob)
+      setPreviewUrl(url)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSharing(false)
+    }
+  }
+
+  const handlePreviewClose = () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    setPreviewUrl(null)
+  }
+
+  const handleDownload = () => {
+    const a = document.createElement('a')
+    a.href = previewUrl
+    a.download = `scrappa-${clip.id}.png`
+    a.click()
+  }
+
   const handleDelete = async () => {
     if (!window.confirm('このクリップを削除しますか？')) return
     setDeleting(true)
@@ -74,6 +102,27 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
       console.error(err)
       setDeleting(false)
     }
+  }
+
+  if (previewUrl) {
+    return createPortal(
+      <div className="modal-overlay" onClick={handlePreviewClose}>
+        <div className="share-preview-content" onClick={(e) => e.stopPropagation()}>
+          <div className="modal-header">
+            <h2 className="modal-title">プレビュー</h2>
+            <button className="modal-close" onClick={handlePreviewClose}>×</button>
+          </div>
+          <div className="share-preview-body">
+            <img src={previewUrl} alt="共有画像プレビュー" className="share-preview-image" />
+          </div>
+          <div className="modal-footer">
+            <button className="cancel-btn" onClick={handlePreviewClose}>戻る</button>
+            <button className="submit-btn" onClick={handleDownload}>保存</button>
+          </div>
+        </div>
+      </div>,
+      document.body
+    )
   }
 
   return createPortal(
@@ -154,9 +203,14 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
           </div>
         </div>
         <div className="modal-footer detail-footer">
-          <button className="delete-btn" onClick={handleDelete} disabled={deleting || saving}>
-            {deleting ? '削除中...' : '削除'}
-          </button>
+          <div className="detail-footer-left">
+            <button className="delete-btn" onClick={handleDelete} disabled={deleting || saving || sharing}>
+              {deleting ? '削除中...' : '削除'}
+            </button>
+            <button className="share-btn" onClick={handleShare} disabled={sharing || saving || deleting}>
+              {sharing ? '生成中...' : '共有'}
+            </button>
+          </div>
           <div className="detail-footer-right">
             {error && <p className="upload-error">{error}</p>}
             <button className="cancel-btn" onClick={onClose} disabled={saving || deleting}>

--- a/frontend/src/lib/generateShareImage.js
+++ b/frontend/src/lib/generateShareImage.js
@@ -1,0 +1,100 @@
+async function createImage(url) {
+  // S3 画像は CORS のためバックエンドプロキシ経由で取得する
+  const isS3 = url.includes('s3.amazonaws.com') || url.includes('s3.ap-northeast')
+  let src = url
+  if (isS3) {
+    src = `/api/image-proxy/?url=${encodeURIComponent(url)}`
+  }
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', reject)
+    image.src = src
+  })
+}
+
+function formatDate(createdAt) {
+  if (!createdAt) return ''
+  const d = new Date(createdAt)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}.${m}.${day}`
+}
+
+// テキストを maxWidth に収まるよう折り返して行配列を返す
+function wrapText(ctx, text, maxWidth) {
+  const words = text.split('')
+  const lines = []
+  let current = ''
+  for (const ch of words) {
+    const candidate = current + ch
+    if (ctx.measureText(candidate).width > maxWidth && current.length > 0) {
+      lines.push(current)
+      current = ch
+    } else {
+      current = candidate
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+/**
+ * チェキ風のシェア画像を生成して PNG Blob を返す
+ * @param {{ image_url: string, created_at?: string, memo?: string }} clip
+ * @returns {Promise<Blob>}
+ */
+export async function generateShareImage(clip) {
+  const SIZE = 1200
+  const SIDE_PAD = 72       // 左右余白
+  const TOP_PAD = 72        // 上余白
+  const BOTTOM_PAD = 220    // 下余白（チェキ感）
+  const IMG_AREA_W = SIZE - SIDE_PAD * 2
+  const IMG_AREA_H = SIZE - TOP_PAD - BOTTOM_PAD
+
+  const img = await createImage(clip.image_url)
+  const canvas = document.createElement('canvas')
+  canvas.width = SIZE
+  canvas.height = SIZE
+  const ctx = canvas.getContext('2d')
+
+  // 白背景
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, SIZE, SIZE)
+
+  // contain: 縦横比を保ちつつ IMG_AREA に収める
+  const scale = Math.min(IMG_AREA_W / img.width, IMG_AREA_H / img.height)
+  const drawW = img.width * scale
+  const drawH = img.height * scale
+  const drawX = SIDE_PAD + (IMG_AREA_W - drawW) / 2
+  const drawY = TOP_PAD + (IMG_AREA_H - drawH) / 2
+  ctx.drawImage(img, drawX, drawY, drawW, drawH)
+
+  // 日付（クリップ画像の右下に配置）
+  const dateStr = formatDate(clip.created_at)
+  if (dateStr) {
+    ctx.font = '400 24px "Helvetica Neue", Arial, sans-serif'
+    ctx.fillStyle = '#aaaaaa'
+    ctx.textAlign = 'right'
+    const dateX = drawX + drawW - 12
+    const dateY = drawY + drawH + 22
+    ctx.fillText(dateStr, dateX, dateY)
+  }
+
+  // メモ（下余白エリアに中央揃え）
+  const textBaseY = TOP_PAD + IMG_AREA_H + 110
+  if (clip.memo) {
+    ctx.font = '400 44px "Helvetica Neue", Arial, sans-serif'
+    ctx.fillStyle = '#999999'
+    ctx.textAlign = 'center'
+    const maxTextWidth = SIZE - SIDE_PAD * 2
+    const lines = wrapText(ctx, clip.memo, maxTextWidth)
+    const lineHeight = 62
+    lines.forEach((line, i) => {
+      ctx.fillText(line, SIZE / 2, textBaseY + i * lineHeight)
+    })
+  }
+
+  return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'))
+}


### PR DESCRIPTION
## 概要

- クリップ詳細モーダルに「共有」ボタンを追加
- 押すとチェキ風デザインの画像を生成してプレビューモーダルを表示
- プレビューの「保存」ボタンで PNG をダウンロード

## 変更内容

- `frontend/src/lib/generateShareImage.js` (新規): Canvas API でチェキ風画像（1200×1200px、白背景、クリップ画像・日付・メモ付き）を生成
- `frontend/src/components/clip/ClipDetailModal.jsx`: 共有ボタン・プレビューモーダルを追加
- `frontend/src/components/clip/ClipDetailModal.css`: 共有ボタン・プレビューモーダルのスタイルを追加
- `backend/app/main.py`: S3 画像の CORS 対策として `/image-proxy/` エンドポイントを追加

## 動作確認

- [ ] 共有ボタンを押すと画像が生成されプレビューが表示される
- [ ] プレビューの「保存」ボタンで PNG がダウンロードされる
- [ ] 日付がクリップ画像右下（重ならない位置）に表示される
- [ ] メモが下余白エリアに表示される（メモなしの場合は非表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)