### PR TITLE
fix: モバイルで共有プレビューが表示されない問題を修正

### DIFF
--- a/frontend/src/components/clip/ClipDetailModal.jsx
+++ b/frontend/src/components/clip/ClipDetailModal.jsx
@@ -64,12 +64,14 @@ export default function ClipDetailModal({ clip, isGuest = false, onClose, onUpda
 
   const handleShare = async () => {
     setSharing(true)
+    setError(null)
     try {
       const blob = await generateShareImage(clip)
       const url = URL.createObjectURL(blob)
       setPreviewUrl(url)
     } catch (err) {
       console.error(err)
+      setError('画像の生成に失敗しました。再度お試しください。')
     } finally {
       setSharing(false)
     }

--- a/frontend/src/lib/generateShareImage.js
+++ b/frontend/src/lib/generateShareImage.js
@@ -1,14 +1,29 @@
 async function createImage(url) {
-  // S3 画像は CORS のためバックエンドプロキシ経由で取得する
+  // S3 画像は Canvas の汚染（tainted）を防ぐため、
+  // fetch() でバイナリ取得 → Blob URL に変換してから <img> に読み込む
+  // （<img src> に直接プロキシURLを渡すだけでは Canvas が汚染され toBlob/toDataURL が失敗する）
   const isS3 = url.includes('s3.amazonaws.com') || url.includes('s3.ap-northeast')
   let src = url
+  let blobUrl = null
+
   if (isS3) {
-    src = `/api/image-proxy/?url=${encodeURIComponent(url)}`
+    const resp = await fetch(`/api/image-proxy/?url=${encodeURIComponent(url)}`)
+    if (!resp.ok) throw new Error('画像の取得に失敗しました')
+    const blob = await resp.blob()
+    blobUrl = URL.createObjectURL(blob)
+    src = blobUrl
   }
+
   return new Promise((resolve, reject) => {
     const image = new Image()
-    image.addEventListener('load', () => resolve(image))
-    image.addEventListener('error', reject)
+    image.addEventListener('load', () => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl)
+      resolve(image)
+    })
+    image.addEventListener('error', (e) => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl)
+      reject(e)
+    })
     image.src = src
   })
 }

--- a/frontend/src/lib/generateShareImage.js
+++ b/frontend/src/lib/generateShareImage.js
@@ -96,5 +96,23 @@ export async function generateShareImage(clip) {
     })
   }
 
-  return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'))
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob)
+      } else {
+        // モバイル Safari など toBlob が null を返す場合は toDataURL でフォールバック
+        try {
+          const dataUrl = canvas.toDataURL('image/png')
+          const byteString = atob(dataUrl.split(',')[1])
+          const ab = new ArrayBuffer(byteString.length)
+          const ia = new Uint8Array(ab)
+          for (let i = 0; i < byteString.length; i++) ia[i] = byteString.charCodeAt(i)
+          resolve(new Blob([ab], { type: 'image/png' }))
+        } catch (e) {
+          reject(new Error('画像の生成に失敗しました'))
+        }
+      }
+    }, 'image/png')
+  })
 }


### PR DESCRIPTION
## 原因

モバイル Safari では `canvas.toBlob()` がメモリ制約などにより `null` を返すことがある。

現状のコードは `null` を受け取ると `URL.createObjectURL(null)` が TypeError を throw し、`catch` で無音で握りつぶされていたため、プレビュー画面が表示されなかった。

## 修正内容

**`frontend/src/lib/generateShareImage.js`**
- `toBlob` が `null` を返した場合に `toDataURL()` → `Blob` 変換のフォールバック処理を追加

**`frontend/src/components/clip/ClipDetailModal.jsx`**
- `handleShare` のエラー時にユーザーへのエラーメッセージを表示するよう修正

## 動作確認

- [ ] PC でプレビュー・ダウンロードが動作する
- [ ] スマホでプレビューが表示される
- [ ] スマホでダウンロードができる
- [ ] 画像生成失敗時にエラーメッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)